### PR TITLE
Fix failing test on Solaris

### DIFF
--- a/core/src/main/groovy/noe/common/utils/JBFile.groovy
+++ b/core/src/main/groovy/noe/common/utils/JBFile.groovy
@@ -1108,6 +1108,7 @@ class JBFile {
             break
           case 's':
             tmpPerm += 1
+          case 'l':
           case 'S':
           case 'L':
             special += (it == 2) ? 4 : 2


### PR DESCRIPTION
For some reason, on Solaris:

`chmod 2010` returns `------s---`, but

`chmod 2000` returns `------l---` which started to happen recently.

Code has underwent a proper code review privately. 