### PR TITLE
Fix RpmTomcatFactory

### DIFF
--- a/core/src/main/groovy/noe/tomcat/configure/envars/RpmTomcatEnvVarsFileFactory.groovy
+++ b/core/src/main/groovy/noe/tomcat/configure/envars/RpmTomcatEnvVarsFileFactory.groovy
@@ -119,12 +119,13 @@ class RpmTomcatEnvVarsFileFactory {
     }
 
     private boolean isCurrentJwsMajorVersion(int majorVersion) {
+      Boolean ret = false
       String versionStr = Library.getUniversalProperty('ews.version')
 
       try {
-        return new Version(versionStr).getMajorVersion() == majorVersion
+        ret = new Version(versionStr).getMajorVersion() == majorVersion
       } finally {
-        return false
+        return ret
       }
     }
   }


### PR DESCRIPTION
Method always return `false` as it was hard coded in finally statement.

"In case of a return statement specifically (since its captioned), the control has to leave the calling method , And hence calls the finally block of the corresponding try-finally structure. The return statement is executed after the finally block."

https://stackoverflow.com/questions/65035/does-a-finally-block-always-get-executed-in-java

Credit @jonderka