### PR TITLE
Add integration tests for JWS5/Tomcat9

### DIFF
--- a/testsuite/src/test/groovy/noe/TomcatJws5IT.groovy
+++ b/testsuite/src/test/groovy/noe/TomcatJws5IT.groovy
@@ -1,0 +1,51 @@
+package noe
+
+import groovy.util.logging.Slf4j
+import noe.common.TestAbstract
+import noe.common.utils.Java
+import noe.common.utils.Platform
+import noe.workspace.ServersWorkspace
+import noe.workspace.WorkspaceTomcat
+import org.junit.Assume
+import org.junit.BeforeClass
+import org.junit.Test
+
+@Slf4j
+class TomcatJws5IT extends TestAbstract {
+
+
+  @BeforeClass
+  public static void beforeClass() {
+    Platform platform = new Platform()
+    Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
+    Assume.assumeTrue("Tomcat from JWS 5 requires at least Java 1.8", Java.isJdk1xOrHigher('1.8'))
+    loadTestProperties('/jws5-test.properties')
+    workspace = new ServersWorkspace(
+            new WorkspaceTomcat()
+    )
+    workspace.prepare()
+  }
+
+
+  @Test
+  void serverStartStopTest() {
+    serverController.getServerIds().each { serverId ->
+      SingleServerTestUtils.serverStartStopTest(serverId)
+    }
+  }
+
+  @Test
+  void serverStartKillTest() {
+    serverController.getServerIds().each { serverId ->
+      SingleServerTestUtils.serverStartKillTest(serverId)
+    }
+  }
+
+  @Test
+  void killAllInSystemTest() {
+    serverController.getServerIds().each { serverId ->
+      SingleServerTestUtils.killAllInSystemTest(serverId)
+    }
+  }
+
+}

--- a/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat9ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat9ConfiguratorIT.groovy
@@ -1,0 +1,19 @@
+package noe.tomcat
+
+import noe.common.utils.Java
+import noe.common.utils.Platform
+import org.junit.Assume
+import org.junit.BeforeClass
+
+class BindingsTomcat9ConfiguratorIT extends BindingsTomcatConfiguratorIT {
+
+  @BeforeClass
+  public static void beforeClass() {
+    Platform platform = new Platform()
+    Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
+    Assume.assumeTrue("Tomcat from JWS 5.0 requires at least Java 1.7", Java.isJdk1xOrHigher('1.8'))
+
+    loadTestProperties("/jws5-test.properties")
+    prepareWorkspace()
+  }
+}

--- a/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat9ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat9ConfiguratorIT.groovy
@@ -13,7 +13,7 @@ class BindingsTomcat9ConfiguratorIT extends BindingsTomcatConfiguratorIT {
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
     Assume.assumeTrue("Tomcat from JWS 5.0 requires at least Java 1.7", Java.isJdk1xOrHigher('1.8'))
 
-    loadTestProperties("/jws5-test.properties")
+    loadTestProperties("/tomcat9-common-test.properties")
     prepareWorkspace()
   }
 }

--- a/testsuite/src/test/groovy/noe/tomcat/JmxTomcat9ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JmxTomcat9ConfiguratorIT.groovy
@@ -13,7 +13,7 @@ class JmxTomcat9ConfiguratorIT extends JmxTomcatConfiguratorIT {
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
     Assume.assumeTrue("Tomcat from JWS 3.0 requires at least Java 1.7", Java.isJdk1xOrHigher('1.8'))
 
-    loadTestProperties("/jws5-test.properties")
+    loadTestProperties("/tomcat9-common-test.properties")
     prepareWorkspace()
   }
 

--- a/testsuite/src/test/groovy/noe/tomcat/JmxTomcat9ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JmxTomcat9ConfiguratorIT.groovy
@@ -1,0 +1,20 @@
+package noe.tomcat
+
+import noe.common.utils.Java
+import noe.common.utils.Platform
+import org.junit.Assume
+import org.junit.BeforeClass
+
+class JmxTomcat9ConfiguratorIT extends JmxTomcatConfiguratorIT {
+
+  @BeforeClass
+  public static void beforeClass() {
+    Platform platform = new Platform()
+    Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
+    Assume.assumeTrue("Tomcat from JWS 3.0 requires at least Java 1.7", Java.isJdk1xOrHigher('1.8'))
+
+    loadTestProperties("/jws5-test.properties")
+    prepareWorkspace()
+  }
+
+}

--- a/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat9ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat9ConfiguratorIT.groovy
@@ -1,0 +1,20 @@
+package noe.tomcat
+
+import noe.common.utils.Java
+import noe.common.utils.Platform
+import org.junit.Assume
+import org.junit.BeforeClass
+
+class JvmRouteTomcat9ConfiguratorIT extends JvmRouteTomcatConfiguratorIT {
+
+  @BeforeClass
+  public static void beforeClass() {
+    Platform platform = new Platform()
+    Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
+    Assume.assumeTrue("Tomcat from JWS 3.0 requires at least Java 1.7", Java.isJdk1xOrHigher('1.8'))
+
+    loadTestProperties("/jws5-test.properties")
+    prepareWorkspace()
+  }
+
+}

--- a/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat9ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat9ConfiguratorIT.groovy
@@ -13,7 +13,7 @@ class JvmRouteTomcat9ConfiguratorIT extends JvmRouteTomcatConfiguratorIT {
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
     Assume.assumeTrue("Tomcat from JWS 3.0 requires at least Java 1.7", Java.isJdk1xOrHigher('1.8'))
 
-    loadTestProperties("/jws5-test.properties")
+    loadTestProperties("/tomcat9-common-test.properties")
     prepareWorkspace()
   }
 

--- a/testsuite/src/test/groovy/noe/tomcat/configure/envars/ConfsBckpRestoreTomcat7ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/configure/envars/ConfsBckpRestoreTomcat7ConfiguratorIT.groovy
@@ -1,6 +1,5 @@
 package noe.tomcat.configure.envars
 
-import noe.tomcat.JvmRouteTomcatConfiguratorIT
 import org.junit.BeforeClass
 
 

--- a/testsuite/src/test/groovy/noe/tomcat/configure/envars/ConfsBckpRestoreTomcat8ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/configure/envars/ConfsBckpRestoreTomcat8ConfiguratorIT.groovy
@@ -1,6 +1,5 @@
 package noe.tomcat.configure.envars
 
-import noe.tomcat.JvmRouteTomcatConfiguratorIT
 import org.junit.BeforeClass
 
 

--- a/testsuite/src/test/groovy/noe/tomcat/configure/envars/ConfsBckpRestoreTomcat9ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/configure/envars/ConfsBckpRestoreTomcat9ConfiguratorIT.groovy
@@ -1,0 +1,13 @@
+package noe.tomcat.configure.envars
+
+import org.junit.BeforeClass
+
+
+class ConfsBckpRestoreTomcat9ConfiguratorIT extends ConfsBckpRestoreTomcatConfiguratorIT {
+
+  @BeforeClass
+   static void beforeClass() {
+    loadTestProperties("/jws5-test.properties")
+    prepareWorkspace()
+  }
+}

--- a/testsuite/src/test/groovy/noe/tomcat/configure/envars/ConfsBckpRestoreTomcat9ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/configure/envars/ConfsBckpRestoreTomcat9ConfiguratorIT.groovy
@@ -7,7 +7,7 @@ class ConfsBckpRestoreTomcat9ConfiguratorIT extends ConfsBckpRestoreTomcatConfig
 
   @BeforeClass
    static void beforeClass() {
-    loadTestProperties("/jws5-test.properties")
+    loadTestProperties("/tomcat9-common-test.properties")
     prepareWorkspace()
   }
 }

--- a/testsuite/src/test/resources/jws5-test.properties
+++ b/testsuite/src/test/resources/jws5-test.properties
@@ -1,0 +1,3 @@
+ews.version=5.0.0
+context=ews
+apache.core.version=2.4.29

--- a/testsuite/src/test/resources/tomcat9-common-test.properties
+++ b/testsuite/src/test/resources/tomcat9-common-test.properties
@@ -1,0 +1,4 @@
+ews.version=5.0.0
+context=ews
+JBPAPP9445_WORKAROUND=true
+tomcat.major.version=9


### PR DESCRIPTION
Unix system passed, waiting for Windows. This MR creates an issue to consolidate integration tests, which often take too long. I believe there's a room for improvement when it comes to duplicating ITs for Tomcat 7-9, which may use the same code-base and classes (i.e. one class being tested 3 times). For now, the consolidation is a TODO.