### PR TITLE
Prepare integration tests for new EAP domain xml

### DIFF
--- a/testsuite/src/test/groovy/noe/SingleServerEap6DomainIT.groovy
+++ b/testsuite/src/test/groovy/noe/SingleServerEap6DomainIT.groovy
@@ -7,6 +7,7 @@ import noe.server.AS7Domain
 import noe.workspace.ServersWorkspace
 import org.junit.BeforeClass
 import org.junit.Test
+import org.junit.Ignore
 
 @Slf4j
 class SingleServerEap6DomainIT extends TestAbstract {
@@ -42,6 +43,8 @@ class SingleServerEap6DomainIT extends TestAbstract {
   }
 
   @Test
+  // https://github.com/web-servers/noe-core/pull/34
+  @Ignore
   void shiftPortsTest() {
     String serverId = serverController.getServerIds().first()
     AS7Domain server = serverController.getServerById(serverId)

--- a/testsuite/src/test/groovy/noe/SingleServerEap7DomainIT.groovy
+++ b/testsuite/src/test/groovy/noe/SingleServerEap7DomainIT.groovy
@@ -16,7 +16,7 @@ class SingleServerEap7DomainIT extends TestAbstract {
   @BeforeClass
   public static void beforeClass() {
     Assume.assumeTrue("EAP 7 requires at least JDK 1.8", new Java().isJdk1xOrHigher('1.8'));
-    loadTestProperties('/eap7-test.properties')
+    loadTestProperties('/eap7-domain-test.properties')
     workspace = new ServersWorkspace(
         new WorkspaceAS7DomainNoHttpd('eap7-domain-1')
     );

--- a/testsuite/src/test/resources/eap7-domain-test.properties
+++ b/testsuite/src/test/resources/eap7-domain-test.properties
@@ -1,0 +1,3 @@
+eap.version=7.2.0.GA.CR4
+ews.version=3.0.0
+context=eap6


### PR DESCRIPTION
Due to #33, I have to change integration tests for the domain mode.

EAP 6 will no longer work for domain mode port shift (hence ignoring). EAP 7 will work from 7.2 onwards.