### PR TITLE
Provide support for server java in the Java class

### DIFF
--- a/core/src/main/groovy/noe/common/utils/Java.groovy
+++ b/core/src/main/groovy/noe/common/utils/Java.groovy
@@ -20,12 +20,12 @@ public class Java {
   private static boolean initialized = false
 
   static {
-    if(serverJavaHome && !initialized) {
-      if(! new File(serverJavaHome, "bin").exists()) {
+    if (serverJavaHome && !initialized) {
+      if (!new File(serverJavaHome, "bin").exists()) {
         return
       }
-      String javac = PathHelper.join(serverJavaHome,"bin","javac")
-      String java = PathHelper.join(serverJavaHome,"bin","java")
+      String javac = PathHelper.join(serverJavaHome, "bin", "javac")
+      String java = PathHelper.join(serverJavaHome, "bin", "java")
       Library.copyResourceTo(javaHelperClassResource, new File("."))
       Cmd.executeCommandConsumeStreams([javac, "JavaVersion.java"])
       javaVersion = Cmd.executeCommandConsumeStreams([java, "JavaVersion", "-version"])["stdOut"].trim()

--- a/core/src/main/groovy/noe/common/utils/Java.groovy
+++ b/core/src/main/groovy/noe/common/utils/Java.groovy
@@ -17,9 +17,10 @@ public class Java {
   public static final String javaHome = System.getenv('JAVA_HOME')
   public static final String serverJavaHome = System.getenv('SERVER_JAVA_HOME')
   private static final String javaHelperClassResource = "java/JavaVersion.java"
+  private static boolean initialized = false
 
   static {
-    if(serverJavaHome) {
+    if(serverJavaHome && !initialized) {
       if(! new File(serverJavaHome, "bin").exists()) {
         return
       }
@@ -31,6 +32,7 @@ public class Java {
       javaVendor = Cmd.executeCommandConsumeStreams([java, "JavaVersion", "-vendor"])["stdOut"].trim()
       javaVmName = Cmd.executeCommandConsumeStreams([java, "JavaVersion", "-vmname"])["stdOut"].trim()
       javaVmInfo = Cmd.executeCommandConsumeStreams([java, "JavaVersion", "-vminfo"])["stdOut"].trim()
+      initialized = true
     }
   }
 

--- a/core/src/main/groovy/noe/common/utils/Java.groovy
+++ b/core/src/main/groovy/noe/common/utils/Java.groovy
@@ -10,11 +10,29 @@ import groovy.util.logging.Slf4j
 @Slf4j
 public class Java {
 
-  public static final String javaVersion = System.getProperty('java.version')
-  public static final String javaVendor = System.getProperty('java.vendor')
-  public static final String javaVmName = System.getProperty('java.vm.name')
-  public static final String javaVmInfo = System.getProperty('java.vm.info')
+  public static String javaVersion = System.getProperty('java.version')
+  public static String javaVendor = System.getProperty('java.vendor')
+  public static String javaVmName = System.getProperty('java.vm.name')
+  public static String javaVmInfo = System.getProperty('java.vm.info')
   public static final String javaHome = System.getenv('JAVA_HOME')
+  public static final String serverJavaHome = System.getenv('SERVER_JAVA_HOME')
+  private static final String javaHelperClassResource = "java/JavaVersion.java"
+
+  static {
+    if(serverJavaHome) {
+      if(! new File(serverJavaHome, "bin").exists()) {
+        return
+      }
+      String javac = PathHelper.join(serverJavaHome,"bin","javac")
+      String java = PathHelper.join(serverJavaHome,"bin","java")
+      Library.copyResourceTo(javaHelperClassResource, new File("."))
+      Cmd.executeCommandConsumeStreams([javac, "JavaVersion.java"])
+      javaVersion = Cmd.executeCommandConsumeStreams([java, "JavaVersion", "-version"])["stdOut"].trim()
+      javaVendor = Cmd.executeCommandConsumeStreams([java, "JavaVersion", "-vendor"])["stdOut"].trim()
+      javaVmName = Cmd.executeCommandConsumeStreams([java, "JavaVersion", "-vmname"])["stdOut"].trim()
+      javaVmInfo = Cmd.executeCommandConsumeStreams([java, "JavaVersion", "-vminfo"])["stdOut"].trim()
+    }
+  }
 
   String toString() {
     "${javaVersion} ${javaVendor} ${javaVmName} ${javaVmInfo}"

--- a/core/src/main/resources/java/JavaVersion.java
+++ b/core/src/main/resources/java/JavaVersion.java
@@ -1,0 +1,20 @@
+class JavaVersion {
+    public static void main(String[] args) {
+        switch (args[0].toLowerCase()) {
+            case "-version":
+                System.out.print(System.getProperty("java.version"));
+                break;
+            case "-vendor":
+                System.out.print(System.getProperty("java.vendor"));
+                break;
+            case "-vmname":
+                System.out.print(System.getProperty("java.vm.name"));
+                break;
+            case "-vminfo":
+                System.out.print(System.getProperty("java.vm.info"));
+                break;
+            default:
+                System.out.print("JavaVersion -version|-vendor|-vmname|-vminfo");
+        }
+    }
+}


### PR DESCRIPTION
With this change, the Java class works when `SERVER_JAVA_HOME` is set. 

We simply compile and run a small helper class and extract properties using `SERVER_JAVA_HOME`. If `SERVER_JAVA_HOME` is not set, nothing changes. 

WDYT? I'm open to more elegant solutions. 