### PR TITLE
Comparing only major version of EAP instead of whole

### DIFF
--- a/core/src/main/groovy/noe/eap/workspace/WorkspaceHttpdAS7.groovy
+++ b/core/src/main/groovy/noe/eap/workspace/WorkspaceHttpdAS7.groovy
@@ -47,7 +47,7 @@ class WorkspaceHttpdAS7 extends WorkspaceAbstract {
     this.eapVersion = Library.getUniversalProperty('eap.version')
     this.ewsVersion = DefaultProperties.apacheCoreVersion() ? '' : Library.getUniversalProperty('ews.version')
 
-    assert new Version(eapVersion) >= new Version("6.0.0")
+    assert new Version(eapVersion).majorVersion >= new Version("6.0.0").majorVersion
     //downloadClusterBench()
     workspaceHttpd = new WorkspaceHttpd()
     workspaceAS7 = new WorkspaceAS7()


### PR DESCRIPTION
When running custom build, the cache job builds up something like "7.x-<date>". This may become incomparable with other valid versions.