### PR TITLE
Add support for RHEL8

### DIFF
--- a/core/src/main/groovy/noe/common/utils/PlatformSuffixHelper.groovy
+++ b/core/src/main/groovy/noe/common/utils/PlatformSuffixHelper.groovy
@@ -35,6 +35,7 @@ class PlatformSuffixHelper {
       else if (platform.isRHEL5()) platformName += "RHEL5-"
       else if (platform.isRHEL6()) platformName += "RHEL6-"
       else if (platform.isRHEL7()) platformName += "RHEL7-"
+      else if (platform.isRHEL8()) platformName += "RHEL8-"
       if (platform.isX86()) {
         platformName += "i686"
       } else if (platform.isX64()) {
@@ -111,6 +112,7 @@ class PlatformSuffixHelper {
       else if (platform.isRHEL5()) platformName += "RHEL5-"
       else if (platform.isRHEL6()) platformName += "RHEL6-"
       else if (platform.isRHEL7()) platformName += "RHEL7-"
+      else if (platform.isRHEL8()) platformName += "RHEL8-"
       if (platform.isX86()) {
         platformName += "i386"
       } else if (platform.isX64()) {

--- a/core/src/main/groovy/noe/ews/utils/JwsNameHelper.groovy
+++ b/core/src/main/groovy/noe/ews/utils/JwsNameHelper.groovy
@@ -93,6 +93,7 @@ class JwsNameHelper {
       if (platform.isRHEL5()) result += 'RHEL5-'
       else if (platform.isRHEL6()) result += 'RHEL6-'
       else if (platform.isRHEL7()) result += 'RHEL7-'
+      else if (platform.isRHEL8()) result += 'RHEL8-'
       if (platform.isX86()) {
         result += "i386"
       } else if (platform.isX64()) {


### PR DESCRIPTION
As requested, after investigation, I found out that after we changed the naming of ZIPs, RHEL8 wasn't added to the naming helper class. This MR makes JWS and JBCS natives installable on RHEL8.

Any objections, @mmadzin ?

Note: This needs to be refactored... 