### PR TITLE
Dir state vault

### DIFF
--- a/core/src/main/groovy/noe/common/utils/DirStateVault.groovy
+++ b/core/src/main/groovy/noe/common/utils/DirStateVault.groovy
@@ -11,8 +11,9 @@ package noe.common.utils
  *
  * Symlinks do not have any special care.
  *
- * There is no manipulation with access rights on items, if item is not accessable,
- * exception is thrown. When items are deleted, `sudo` is applied if simple delete does not work.
+ * There is manipulation with access rights on items, if item is not accessible it's access rights are changed
+ * temporalily for time if saving or restoring state, To enable this functionality NOE has to be executed with
+ * -Drun.with.sudo=true.
  *
  * Each record/pushed directory is handled individually, implication is that push of subdirectory of
  * already pushed directory is handled separately. There is no logic checking relation between pushed directories.
@@ -74,8 +75,8 @@ class DirStateVault implements StateVault<DirStateVault> {
 
     // all files in directory are handle by 1 FileStateVault instance and
     // all directories are handled by 1 DirStateVault instance
-    StateVault filesInDirFileStateVault
-    StateVault dirsInDirStateVault
+    FileStateVault filesInDirFileStateVault
+    DirStateVault dirsInDirStateVault
 
     if (!toStore.exists()) {
       dirState.existed = false
@@ -112,7 +113,7 @@ class DirStateVault implements StateVault<DirStateVault> {
 
   private void makeDirAccessibleIfItIsNot(File dir) {
     if (!isWindows && !(dir.canRead() && dir.canExecute() && dir.canExecute())) {
-      JBFile.chmod('o+rwx')
+      JBFile.chmod('u+rwx', dir)
     }
   }
 
@@ -244,7 +245,7 @@ class DirStateVault implements StateVault<DirStateVault> {
         }
 
       } else {
-        throw IllegalStateException("Can not access to target ${existingItemInToRestoreFolder}")
+        throw new IllegalStateException("Can not access to target ${existingItemInToRestoreFolder}")
       }
 
     }

--- a/core/src/main/groovy/noe/common/utils/DirStateVault.groovy
+++ b/core/src/main/groovy/noe/common/utils/DirStateVault.groovy
@@ -73,6 +73,10 @@ class DirStateVault implements StateVault<DirStateVault> {
     initItem(toStore)
     DirState dirState = new DirState(toStore)
 
+    if (toStore.isFile()) {
+      throw new IllegalStateException("Target to store '${toStore}' is not directory.")
+    }
+
     // all files in directory are handle by 1 FileStateVault instance and
     // all directories are handled by 1 DirStateVault instance
     FileStateVault filesInDirFileStateVault

--- a/core/src/main/groovy/noe/common/utils/DirStateVault.groovy
+++ b/core/src/main/groovy/noe/common/utils/DirStateVault.groovy
@@ -1,0 +1,234 @@
+package noe.common.utils
+
+/**
+ * Service class for storing and restoring of directories states.
+ * State means content of files in directory and subdirectories or information whether files
+ * and subdirectories does not exist.
+ *
+ * State is stored in memory.
+ *
+ * If non existing directory is given, it is deleted on restore if exists at the moment.
+ *
+ * Symlinks do not have any special care.
+ *
+ * There is no manipulation with access rights on files, only exception is when file
+ * is being removed - when normal delete fails deleting with sudo is activated (if enabled).
+ *
+ * Each record/pushed directory is handled individually, implication is that push of subdirectory of
+ * already pushed directory is handled separately. There is no logic checking relation between pushed directories.
+ *
+ * For work with files only check class FileStateVault
+ *
+ * @see FileStateVault
+ * @see JBFile#delete
+ */
+class DirStateVault implements StateVault<DirStateVault> {
+  private Map<String, List<DirState>> vault = [:]
+
+  static class DirState {
+    FileStateVault fileStateVault
+    DirStateVault dirStateVault
+    boolean existed = true
+
+    boolean isEmpty() {
+      return fileStateVault == null && dirStateVault == null
+    }
+  }
+
+  /**
+   * If directory toStore does exist it's current content is stored into memory.
+   * If does not then this fact is just noted.
+   *
+   * All subdirectories are handled recursively.
+   *
+   * The state of the file can be loaded by `pop(...)` or `popAll()` methods, they restore
+   * last saved state and delete this state from memory.
+   */
+  @Override
+  DirStateVault push(File toStore) {
+    initItem(toStore)
+    DirState dirState = new DirState()
+
+    // all files in directory are handle by 1 FileStateVault instance and
+    // all directories are handled by 1 DirStateVault instance
+    StateVault filesInDirFileStateVault
+    StateVault dirsInDirStateVault
+
+    if (!toStore.exists()) {
+      DirState ds = new DirState()
+      ds.existed = false
+      vault.get(key(toStore)).add(ds)
+    } else {
+      toStore.listFiles().each { File item ->
+        if (item.isFile() && item.canRead()) {
+          filesInDirFileStateVault = (filesInDirFileStateVault ?: new FileStateVault()).push(item)
+        } else if (item.isDirectory() && item.canRead() && item.canExecute()) {
+          dirsInDirStateVault = (dirsInDirStateVault ?: new DirStateVault()).push(item)
+        } else {
+          throw new IllegalStateException("Target to store '${toStore}' is not accessible.")
+        }
+      }
+
+      if (filesInDirFileStateVault) {
+        dirState.fileStateVault = filesInDirFileStateVault
+      }
+      if (dirsInDirStateVault) {
+        dirState.dirStateVault = dirsInDirStateVault
+      }
+
+      if (!dirState.isEmpty()) {
+        vault.get(key(toStore)).add(dirState)
+      }
+    }
+
+    return this
+  }
+
+  /**
+   * Restores last saved state of all directories and remove those states from memory.
+   * If information that file did not exist was found, file is deleted.
+   *
+   * @see JBFile#delete
+   */
+  @Override
+  DirStateVault pop() {
+    Set<String> keys = Collections.unmodifiableCollection(vault.keySet())
+
+    keys.each {String key ->
+      pop(file(key))
+    }
+
+    return this
+  }
+
+  /**
+   * Restores last known state of given file and remove that state from memory.
+   * If information that file did not exist was found, file is deleted.
+   *
+   * @see JBFile#delete
+   */
+  @Override
+  DirStateVault pop(File toRestore) {
+    if (!vault.containsKey(key(toRestore)) || vault.get(key(toRestore)).size() == 0) {
+      throw new IllegalStateException("Target to re-store '${toRestore}' does not exist in vault.")
+    }
+
+    DirState dirState = vault.get(key(toRestore)).last()
+    FileStateVault fileStateVault = dirState?.fileStateVault
+    DirStateVault dirStateVault = dirState?.dirStateVault
+    restoreDirectory(toRestore, fileStateVault, dirStateVault)
+
+    vault.get(key(toRestore)).pop()
+    if (vault.get(key(toRestore)).isEmpty()) {
+      vault.remove(key(toRestore))
+    }
+
+    return this
+  }
+
+  /**
+   * Restore all stored directories to first state, all other states are not applied and are removed from memory.
+   *
+   * @see JBFile#delete
+   * @see FileStateVault#pop
+   */
+  @Override
+  DirStateVault popAll() {
+    Set<String> keys = Collections.unmodifiableCollection(vault.keySet())
+
+    keys.each { String key ->
+      popAll(file(key))
+    }
+
+    vault.clear()
+
+    return this
+  }
+
+  /**
+   * Restore to first state, all other states are not applied and are removed from memory.
+   *
+   * @see JBFile#delete
+   */
+  @Override
+  DirStateVault popAll(File toRestore) {
+    if (!vault.containsKey(key(toRestore)) || vault.get(key(toRestore)).size() == 0) {
+      throw new IllegalStateException("Target to re-store '${toRestore}' does not exist in vault.")
+    }
+
+    FileStateVault fileStateVault = vault.get(key(toRestore)).first()?.fileStateVault
+    DirStateVault dirStateVault = vault.get(key(toRestore)).first()?.dirStateVault
+    restoreDirectory(toRestore, fileStateVault, dirStateVault)
+
+    vault.remove(key(toRestore))
+
+    return this
+  }
+
+  /**
+   * Checks whether the file is pushed to vault already.
+   */
+  @Override
+  boolean isPushed(File file) {
+    return vault.containsKey(key(file))
+  }
+
+  private void initItem(File toStore) {
+    if (!vault.containsKey(key(toStore))) {
+      vault.put(key(toStore), [])
+    }
+  }
+
+  private void restoreDirectory(File toRestore, FileStateVault fileStateVault, DirStateVault dirStateVault) {
+    boolean fileDidExist
+    boolean dirDidExist
+
+    // directory did ont exists -> delete
+    if (!vault.get(key(toRestore)).last().existed) {
+      JBFile.delete(toRestore)
+      return
+    }
+
+    // target exists but it is file not directory and directory existed (not returned in previous step)
+    if (toRestore.exists() && toRestore.isFile()) {
+      JBFile.delete()
+      toRestore.mkdirs()
+    }
+
+    // remove anything new
+    toRestore.listFiles().each { File existingItemInToRestoreFolder ->
+
+      if (existingItemInToRestoreFolder.isFile()) {
+
+        fileDidExist = (fileStateVault) ? (fileStateVault?.isPushed(existingItemInToRestoreFolder)) : false
+        if (!fileDidExist) {
+          JBFile.delete(existingItemInToRestoreFolder)
+        }
+
+      } else if (existingItemInToRestoreFolder.isDirectory()) {
+
+        dirDidExist = (dirStateVault) ? (dirStateVault?.isPushed(existingItemInToRestoreFolder)) : false
+        if (!dirDidExist) {
+          JBFile.delete(existingItemInToRestoreFolder)
+        }
+
+      } else {
+        throw IllegalStateException("Can not access to target ${existingItemInToRestoreFolder}")
+      }
+
+    }
+
+    // now, there are only files what was pushed, any missing, will be recovered as well as state of existing
+    fileStateVault?.pop()
+    dirStateVault?.pop()
+  }
+
+  private String key(File file) {
+    return file.getCanonicalPath()
+  }
+
+  private File file(String key) {
+    return new File(key)
+  }
+
+}

--- a/core/src/main/groovy/noe/common/utils/FileStateVault.groovy
+++ b/core/src/main/groovy/noe/common/utils/FileStateVault.groovy
@@ -46,7 +46,7 @@ class FileStateVault implements StateVault {
 
     private void makeTheFileReadableIfItIsNot(File file) {
       if (!isWindows && !file.canRead()) {
-        JBFile.chmod('o+r', file)
+        JBFile.chmod('ugo+r', file)
       }
     }
 
@@ -66,7 +66,7 @@ class FileStateVault implements StateVault {
 
     private void makeFileWriteableIfItIsNot(File restoreTarget) {
       if (!isWindows && !restoreTarget.canWrite()) {
-        JBFile.chmod('o+w', restoreTarget)
+        JBFile.chmod('ugo+w', restoreTarget)
       }
     }
 

--- a/core/src/main/groovy/noe/common/utils/FileStateVault.groovy
+++ b/core/src/main/groovy/noe/common/utils/FileStateVault.groovy
@@ -31,7 +31,7 @@ class FileStateVault {
     if (!toStore.exists()) {
       initItem(toStore)
       vault.get(key(toStore)).add(DID_NOT_EXIST)
-    } else if (toStore.isFile()) {
+    } else if (toStore.isFile() && toStore.canRead()) {
       initItem(toStore)
       vault.get(key(toStore)).add(toStore.getBytes())
     } else {

--- a/core/src/main/groovy/noe/common/utils/FileStateVault.groovy
+++ b/core/src/main/groovy/noe/common/utils/FileStateVault.groovy
@@ -11,14 +11,15 @@ package noe.common.utils
  *
  * Symlinks do not have any special care.
  *
- * There is no manipulation with access rights on file, if file is not accessable,
- * exception is thrown. When file is deleted, `sudo` is applied if simple delete does not work.
+ * There is manipulation with access rights on items, if item is not accessible it's access rights are changed
+ * temporalily for time if saving or restoring state, To enable this functionality NOE has to be executed with
+ * -Drun.with.sudo=true.
  *
  * @see JBFile#delete
  * @see DirStateVault
  *
  */
-class FileStateVault implements StateVault {
+class FileStateVault implements StateVault<FileStateVault> {
   Map<String, List<FileState>> vault = [:]
   private boolean isWindows = new Platform().isWindows()
 

--- a/core/src/main/groovy/noe/common/utils/StateVault.groovy
+++ b/core/src/main/groovy/noe/common/utils/StateVault.groovy
@@ -1,0 +1,43 @@
+package noe.common.utils
+
+interface StateVault<U> {
+
+  /**
+   * If item toStore does exist it's current content is stored into memory.
+   * If does not then this fact is just noted.
+   *
+   * All subitems are handled recursively.
+   *
+   * The state of the item can be loaded by `pop(...)` or `popAll()` methods, they restore
+   * last saved state and delete this state from memory.
+   */
+  U push(File toStore)
+
+  /**
+   * Restores last known state of given item and remove that state from memory.
+   * If information that file did not exist was found, file is deleted.
+   */
+  U pop(File toRestore)
+
+  /**
+   * Restores last saved state of all directories and remove those states from memory.
+   * If information that file did not exist was found, file is deleted.
+   */
+  U pop()
+
+  /**
+   * Restore all stored items to first state, all other states are not applied
+   * and are removed from memory.
+   */
+  U popAll(File toRestore)
+
+  /**
+   * Restore all pushed items to first state, all other states are not applied and are removed from memory.
+   */
+  U popAll()
+
+  /**
+   * Checks whether the file is pushed to vault already.
+   */
+  boolean isPushed(File file)
+}

--- a/core/src/test/groovy/noe/common/utils/DirStateVaultTest.groovy
+++ b/core/src/test/groovy/noe/common/utils/DirStateVaultTest.groovy
@@ -1,0 +1,231 @@
+package noe.common.utils
+
+import groovy.io.FileType
+import org.junit.Assert
+import org.junit.Assume
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+
+class DirStateVaultTest {
+  List firstLevelDir = []
+  byte[] fileContentToTest
+  final static int TEST_FILE_LENGTH = 200
+  final static int FILES_PER_FOLDER = 3
+  final static int FOLDERS_PER_FOLDER = 2
+
+  @Rule
+  public TemporaryFolder testFolder = new TemporaryFolder();
+  File testDir
+
+
+  @Before
+  void prepareTestFile() {
+    testDir = testFolder.newFolder()
+
+    for (int i=0; i < FILES_PER_FOLDER; i++) {
+      File workspace = new File(testDir, "junit-my-${i}.tmp")
+      workspace.createNewFile()
+
+      fileContentToTest = new byte[TEST_FILE_LENGTH]
+      new Random().nextBytes(fileContentToTest)
+      workspace.setBytes(fileContentToTest)
+
+      firstLevelDir.add(workspace)
+    }
+
+    for (int i=0; i < FOLDERS_PER_FOLDER; i++) {
+      File workspace = new File(testDir, "my-folder-${i}")
+      workspace.mkdirs()
+      List<File> dir = []
+
+      for (int j=0; j < FILES_PER_FOLDER; j++) {
+        File targetFile = new File(workspace, "my-file-${j}.tmp")
+        targetFile.createNewFile()
+
+        fileContentToTest = new byte[TEST_FILE_LENGTH]
+        new Random().nextBytes(fileContentToTest)
+        targetFile.setBytes(fileContentToTest)
+
+        dir.add(targetFile)
+      }
+
+      firstLevelDir.add(dir)
+    }
+
+  }
+
+  @Test
+  void pushPopDirFilesAddedShouldBeRemoved() {
+    DirStateVault vault = new DirStateVault().push(testDir)
+    File file = new File(testDir, "this-file-must-not-exists-after-pop.tmp")
+    file.createNewFile()
+
+    File dir = new File(testDir, 'this-dir-must-not-exists-after-pop')
+    dir.mkdirs()
+    File file1 = new File(dir, 'dummy1.tmp')
+    File file2 = new File(dir, 'dummy2.tmp')
+    [file1,file2]*.createNewFile()
+
+    Assert.assertTrue("Test environment was not created successfully (${file})", file.exists())
+    Assert.assertTrue("Test environment was not created successfully (${dir})", dir.exists())
+    Assert.assertTrue("Test environment was not created successfully (${file1})", file1.exists())
+    Assert.assertTrue("Test environment was not created successfully (${file2})", file2.exists())
+    Assert.assertTrue("Testing directory was pushed, it should be registered in vault.", vault.isPushed(testDir))
+
+    vault.pop(testDir)
+
+    Assert.assertFalse(
+      "The testing file (${file}) can not exists after pop operation (this could be unstable on windows due to mechanism locking of files)",
+      file.exists()
+    )
+    Assert.assertFalse(
+      "The testing file (${dir}) can not exists after pop operation (this could be unstable on windows due to mechanism locking of files)",
+      dir.exists()
+    )
+    Assert.assertFalse(
+      "The testing file (${file1}) can not exists after pop operation (this could be unstable on windows due to mechanism locking of files)",
+      file1.exists()
+    )
+    Assert.assertFalse(
+      "The testing file (${file2}) can not exists after pop operation (this could be unstable on windows due to mechanism locking of files)",
+      file2.exists()
+    )
+
+    Assert.assertFalse("Testing directory was popped out, it should not be in vault yet.", vault.isPushed(testDir))
+  }
+
+  @Test
+  void nonExistingDirectoryIsPushed() {
+    File dir = new File(testDir, 'i-have-never-existed-physically')
+    DirStateVault vault = new DirStateVault().push(dir)
+
+    Assume.assumeFalse("Directory (${dir}) must not exists.", dir.exists())
+    Assert.assertTrue("Testing directory was pushed, it should be registered in vault.", vault.isPushed(dir))
+
+    vault.pop(dir)
+
+    Assert.assertFalse("Testing directory was pushed and then poped, it must not be registered in vault.", vault.isPushed(dir))
+    Assert.assertFalse("Directory (${dir}) must not exists.", dir.exists())
+  }
+
+  @Test
+  void pushRemoveFilesDirPopRemovedMustBeReverted() {
+    LinkedHashMap<File, byte[]> origContent = loadContentFromFiles()
+    DirStateVault vault = new DirStateVault().push(testDir)
+
+    testDir.deleteDir()
+
+    vault.pop(testDir)
+
+    testDir.eachFileRecurse { File item ->
+      Assert.assertTrue("The items (${item}) must exists after pop operation.", item.exists())
+      if (item.isFile()) {
+        Assert.assertTrue("Restored data differs from original data", origContent.get(item) == item.getBytes())
+      }
+    }
+  }
+
+  @Test
+  void pushModifyFilesPopModifiedMustBeReverted() {
+    LinkedHashMap<File, byte[]> origContent = loadContentFromFiles()
+    DirStateVault vault = new DirStateVault().push(testDir)
+
+    modifyFilesInTestDir('footer')
+
+    vault.pop(testDir)
+
+    contentEqual(origContent)
+  }
+
+  @Test
+  void pushModifyPushModifyPopPop(){
+    LinkedHashMap<File, byte[]> origContent = loadContentFromFiles()
+    DirStateVault vault = new DirStateVault().push(testDir)
+
+    modifyFilesInTestDir('footer1')
+    LinkedHashMap<File, byte[]> contentChanged1 = loadContentFromFiles()
+    vault.push(testDir)
+    Assert.assertTrue("Testing directory was pushed, it should be registered in vault.", vault.isPushed(testDir))
+
+    modifyFilesInTestDir('footer2')
+    LinkedHashMap<File, byte[]> contentChanged2 = loadContentFromFiles()
+    contentEqual(contentChanged2)
+
+    vault.pop(testDir)
+    contentEqual(contentChanged1)
+    Assert.assertTrue("Testing directory was pushed, it should be registered in vault.", vault.isPushed(testDir))
+
+    vault.pop(testDir)
+    contentEqual(origContent)
+    Assert.assertFalse("Testing directory was popped out, it should not be in vault yet.", vault.isPushed(testDir))
+  }
+
+  @Test
+  void pushPushSubdirModifyPushSubdirModifyPushSubdirPopParent() {
+    LinkedHashMap<File, byte[]> origContent = loadContentFromFiles()
+    DirStateVault vault = new DirStateVault().push(testDir)
+
+    File subDir = new File(testDir, 'my-folder-0')
+    vault.push(subDir)
+    modifyFilesInTestDir('footer1')
+    vault.push(subDir)
+    modifyFilesInTestDir('footer2')
+
+    vault.pop(testDir)
+    contentEqual(origContent)
+
+    Assert.assertFalse("Testing directory was pushed, it should be registered in vault.", vault.isPushed(testDir))
+    Assert.assertTrue("Testing directory was popped out, it should not be in vault yet.", vault.isPushed(subDir))
+  }
+
+  @Test
+  void pushPushPushOtherPopAll(){
+    LinkedHashMap<File, byte[]> origContent = loadContentFromFiles()
+    DirStateVault vault = new DirStateVault().push(testDir)
+    modifyFilesInTestDir('footer1')
+    vault.push(testDir)
+
+    File lvlDir = testFolder.newFolder('lvl1')
+    new File(lvlDir, 'fileLvl1').createNewFile()
+
+    vault.push(lvlDir)
+    File shouldNotExists1 = new File(lvlDir, 'should-not-exists-after-popall1')
+    shouldNotExists1.createNewFile()
+
+    vault.push(lvlDir)
+    File shouldNotExists2 = new File(lvlDir, 'should-not-exists-after-popall2')
+    shouldNotExists2.createNewFile()
+
+    vault.popAll()
+
+    Assert.assertFalse("File ($shouldNotExists1) should not exists after popall()", shouldNotExists1.exists())
+    Assert.assertFalse("File ($shouldNotExists2) should not exists after popall()", shouldNotExists2.exists())
+
+    contentEqual(origContent)
+  }
+
+  private LinkedHashMap<File, byte[]> loadContentFromFiles() {
+    Map<File, byte[]> origData = [:]
+    testDir.eachFileRecurse(FileType.FILES) { File item ->
+      origData.put(item, item.getBytes())
+    }
+
+    return origData
+  }
+
+  private contentEqual(origContent) {
+    testDir.eachFileRecurse(FileType.FILES) { File file ->
+      Assert.assertTrue("Restored data differs from original data", origContent.get(file) == file.getBytes())
+    }
+  }
+
+  private modifyFilesInTestDir(String text) {
+    testDir.eachFileRecurse(FileType.FILES) { File item ->
+      item.setText(item.getText() + "${text}")
+    }
+  }
+
+}


### PR DESCRIPTION
At first, I was thinking to handle directories within `FileStateVault` but it turned out, that would be a mess. Main problem what I saw was in conflicting records (what with files in already pushed directories). It could be implementable of course, but it would had to be documented well and I am not convinced by clearness/cleanliness of such a solution. 

For 'natural semantic sake', I handle directories in separate class.