### PR TITLE
Fix to properly wait for all cmd output to be processed and passed.

### DIFF
--- a/core/src/main/groovy/noe/common/StreamFiller.java
+++ b/core/src/main/groovy/noe/common/StreamFiller.java
@@ -1,0 +1,43 @@
+package noe.common;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Simple stream filler to pass text input.
+ */
+public class StreamFiller extends Thread {
+    private static final Logger log = LoggerFactory.getLogger(StreamFiller.class);
+
+    OutputStream output;
+    InputStream input;
+
+    public StreamFiller(OutputStream output, InputStream input) {
+        this.output = output;
+        this.input = input;
+    }
+
+    /**
+     * streams given text input to output stream
+     */
+    public void run() {
+        if (input != null) {
+            byte[] buffer = new byte[1024];
+            int read = 0;
+            try {
+                while ((read = input.read(buffer)) != -1) {
+                    output.write(buffer, 0, read);
+                }
+                input.close();
+                output.close();
+            } catch (IOException ioe) {
+                log.warn("Exception detected when processing input/output", ioe);
+            }
+        }
+    }
+}
+

--- a/core/src/main/groovy/noe/common/utils/Cmd.groovy
+++ b/core/src/main/groovy/noe/common/utils/Cmd.groovy
@@ -122,10 +122,11 @@ public class Cmd {
     StreamFiller stdIn = new StreamFiller(process.getOutputStream(), input)
     stdIn.start()
 
-    process.waitForProcessOutput(output,error);
+    process.waitForProcessOutput(output,error)
+    final int errCode = process.waitFor()
     stdIn.join(5000)
 
-    return process.waitFor()
+    return errCode
   }
 
   /**
@@ -309,9 +310,10 @@ public class Cmd {
 
     // TODO parametrized input, output streams
     process.waitForProcessOutput(System.out, System.err)
+    final int errCode = process.waitFor()
     stdIn.join(5000)
 
-    return process.waitFor()
+    return errCode
   }
 
   /**


### PR DESCRIPTION
As per JavaDoc of Process.consumeProcessOutput() [1], it is not enough
to call Process.waitFor() to be sure all the StdOut and StdErr data are
processed. It is necessary to call Process.waitForProcessOutput() [2] instead.
Unfortunately the latter method is blocking, thus other code changes are
required to achieve desired behaviour.

[1] http://docs.groovy-lang.org/docs/groovy-2.4.8/html/groovy-jdk/java/lang/Process.html#consumeProcessOutput(java.io.OutputStream,%20java.io.OutputStream)
[2] http://docs.groovy-lang.org/docs/groovy-2.4.8/html/groovy-jdk/java/lang/Process.html#waitForProcessOutput(java.io.OutputStream,%20java.io.OutputStream)