### PR TITLE
Extends Tomcat's https connector configuration

### DIFF
--- a/core/src/main/groovy/noe/tomcat/configure/SecureHttpConnectorTomcat.groovy
+++ b/core/src/main/groovy/noe/tomcat/configure/SecureHttpConnectorTomcat.groovy
@@ -20,6 +20,7 @@ public class SecureHttpConnectorTomcat extends ConnectorTomcatAbstract<SecureHtt
   //
   // SSL common
   private boolean sslEnabled
+  private String protocol
 
   // SSL BIO and NIO
   private String sslProtocol
@@ -50,6 +51,10 @@ public class SecureHttpConnectorTomcat extends ConnectorTomcatAbstract<SecureHtt
     return this.sslEnabled
   }
 
+  public String getProtocol() {
+    return protocol
+  }
+
   public Boolean getClientAuth() {
     return this.clientAuth
   }
@@ -76,6 +81,11 @@ public class SecureHttpConnectorTomcat extends ConnectorTomcatAbstract<SecureHtt
 
   public String getSslPassword() {
     return this.sslPassword
+  }
+
+  public SecureHttpConnectorTomcat setProtocol(String protocol) {
+    this.protocol = protocol
+    return this
   }
 
   public SecureHttpConnectorTomcat setSslProtocol(String sslProtocol) {


### PR DESCRIPTION
Extends Tomcat's https connector configuration for being able to set "protocol" parameter e.g. "org.apache.coyote.http11.Http11AprProtocol"