### PR TITLE
JDK 11 uses ProcessImpl class instead of UNIXProcess class.

### DIFF
--- a/core/src/main/groovy/noe/common/utils/processid/ProcessUtils.groovy
+++ b/core/src/main/groovy/noe/common/utils/processid/ProcessUtils.groovy
@@ -59,7 +59,8 @@ public final class ProcessUtils {
     public static int getUnixProcessId(final Process process) {
         int processId = UNDEFINED_PROCESS_ID;
 
-        if (process.getClass().getName().equals("java.lang.UNIXProcess")) {
+        if (process.getClass().getName().equals("java.lang.UNIXProcess")
+                || process.getClass().getName().equals("java.lang.ProcessImpl")) {
             /* get the PID on unix/linux systems */
             try {
                 Field f = process.getClass().getDeclaredField("pid");


### PR DESCRIPTION
From JDK 9, UNIXProcess class is merged into ProcessImpl class. See [JDK-8071481](https://bugs.openjdk.java.net/browse/JDK-8071481).