### PR TITLE
enforce tomcat.major.version for tests

### DIFF
--- a/testsuite/src/test/resources/jws31-test.properties
+++ b/testsuite/src/test/resources/jws31-test.properties
@@ -1,2 +1,3 @@
 ews.version=3.1.0
 context=ews
+tomcat.major.version=7

--- a/testsuite/src/test/resources/jws4-test.properties
+++ b/testsuite/src/test/resources/jws4-test.properties
@@ -1,2 +1,3 @@
 ews.version=4.0.0-DR1
 context=ews
+tomcat.major.version=8

--- a/testsuite/src/test/resources/jws5-test.properties
+++ b/testsuite/src/test/resources/jws5-test.properties
@@ -1,3 +1,4 @@
 ews.version=5.0.0
 context=ews
 apache.core.version=2.4.29
+tomcat.major.version=9


### PR DESCRIPTION
There was failing integration test  because of change we did wrt tomcat.major.version.