### PR TITLE
Introduces architecture separator for Windows and Solaris packages

### DIFF
--- a/core/src/main/groovy/noe/ews/utils/EwsUtils.groovy
+++ b/core/src/main/groovy/noe/ews/utils/EwsUtils.groovy
@@ -131,11 +131,11 @@ class EwsUtils extends InstallerUtils {
 
   private void loadEwsZipNamesInCompatibilityMode() {
     try {
-      nameHelper.setArchSeparator("-")
+      nameHelper.archSeparator = "-"
       loadEwsZipNames()
       installJwsZips()
     } catch (FileNotFoundException e) {
-      nameHelper.setArchSeparator(".")
+      nameHelper.archSeparator = "."
       loadEwsZipNames(true)
       installJwsZips()
     }

--- a/core/src/main/groovy/noe/ews/utils/EwsUtils.groovy
+++ b/core/src/main/groovy/noe/ews/utils/EwsUtils.groovy
@@ -125,6 +125,17 @@ class EwsUtils extends InstallerUtils {
     try {
       installJwsZips()
     } catch (FileNotFoundException e) {
+      loadEwsZipNamesInCompatibilityMode()
+    }
+  }
+
+  private void loadEwsZipNamesInCompatibilityMode() {
+    try {
+      nameHelper.setArchSeparator("-")
+      loadEwsZipNames()
+      installJwsZips()
+    } catch (FileNotFoundException e) {
+      nameHelper.setArchSeparator(".")
       loadEwsZipNames(true)
       installJwsZips()
     }

--- a/core/src/main/groovy/noe/ews/utils/JwsNameHelper.groovy
+++ b/core/src/main/groovy/noe/ews/utils/JwsNameHelper.groovy
@@ -15,6 +15,7 @@ class JwsNameHelper {
   Version version
   int jwsMajorVersion
   boolean compatibilityMode = false
+  String archSeparator
   Platform platform
   String productName
 
@@ -23,6 +24,7 @@ class JwsNameHelper {
     this.jwsMajorVersion = version.majorVersion
     this.platform = new Platform()
     productName = jwsMajorVersion <= 2 ? "jboss-ews" : "jws"
+    archSeparator = "."
   }
 
   /**
@@ -105,13 +107,13 @@ class JwsNameHelper {
             " osVersion: ${platform.osVersion}, archModel: ${platform.archModel}, solPreferredArch: ${platform.solPreferredArch}")
       }
     } else if (platform.isWindows()) {
-      result += (platform.isX86() ? "win6.i686" : "win6.x86_64")
+      result += (platform.isX86() ? "win6${archSeparator}i686" : "win6${archSeparator}x86_64")
     } else if (platform.isSolaris()) {
       String ver = '10' // on Solaris 10 and 11 -> build for 10
       String os = 'sun'
-      if (platform.isSparc()) result += "${os}${ver}.sparc64"
+      if (platform.isSparc()) result += "${os}${ver}${archSeparator}sparc64"
       else if (platform.getSolPreferredArch() == 32) result += "${os}${ver}.i386"
-      else result += "${os}${ver}.x86_64"
+      else result += "${os}${ver}${archSeparator}x86_64"
     }
     return result
   }
@@ -121,5 +123,13 @@ class JwsNameHelper {
    */
   void toggleCompatibilityMode() {
     this.compatibilityMode = !compatibilityMode
+  }
+
+  /**
+   * Sets architecture separator so that you can get old/new naming scheme of the zipnames.
+   * Architecture separator is used only for Windows and Solaris packages.
+   */
+  void setArchSeparator(String separator) {
+    this.archSeparator = separator
   }
 }

--- a/core/src/main/groovy/noe/ews/utils/JwsNameHelper.groovy
+++ b/core/src/main/groovy/noe/ews/utils/JwsNameHelper.groovy
@@ -124,12 +124,4 @@ class JwsNameHelper {
   void toggleCompatibilityMode() {
     this.compatibilityMode = !compatibilityMode
   }
-
-  /**
-   * Sets architecture separator so that you can get old/new naming scheme of the zipnames.
-   * Architecture separator is used only for Windows and Solaris packages.
-   */
-  void setArchSeparator(String separator) {
-    this.archSeparator = separator
-  }
 }


### PR DESCRIPTION
New pattern for package name was introduce, these modifications reflects the change and allows to use both (new and old) naming patterns.