### PR TITLE
Ignore postinstall output

### DIFF
--- a/core/src/main/groovy/noe/jbcs/utils/HttpdHelper.groovy
+++ b/core/src/main/groovy/noe/jbcs/utils/HttpdHelper.groovy
@@ -150,7 +150,9 @@ class HttpdHelper {
     if (Boolean.valueOf(Library.getUniversalProperty('JWS_198_WORKAROUND', false))) {
       JBFile.replace(new File(httpdBasedir, "etc${sep}httpd${sep}conf${sep}httpd.conf"), "<Files ~ \".ht*\">", "<Files ~ \"^\\.ht\">", true)
     }
-    if ( postInstallOutput.exitValue == 0 || postInstallOutput.exitValue == 17) { // 17 means postinstall was already executed
+    // Ignore any output from the postinstall script, it should be used with caution.
+    boolean ignorePostinstallOutput = Boolean.valueOf(Library.getUniversalProperty('IGNORE_POSTINSTALL_OUTPUT', false))
+    if (ignorePostinstallOutput || postInstallOutput.exitValue == 0 || postInstallOutput.exitValue == 17) { // 17 means postinstall was already executed
       if (postInstallOutput.exitValue == 17) {
         log.warn("Postinstall was already executed for " + httpd.getServerId())
       }


### PR DESCRIPTION
So that any errors generated during .postinstall can be ignored when installed using a non root user and this should help cure the issues created by JBCS-813.