### PR TITLE
HttpdRpm class variable permissions relaxation

### DIFF
--- a/core/src/main/groovy/noe/ews/server/httpd/HttpdRpm.groovy
+++ b/core/src/main/groovy/noe/ews/server/httpd/HttpdRpm.groovy
@@ -17,8 +17,8 @@ import noe.server.Httpd
 @TypeChecked
 @Slf4j
 class HttpdRpm extends Httpd {
-  protected String serviceName
-  protected String apxsPath
+  String serviceName
+  String apxsPath
 
   HttpdRpm(String basedir, version) {
     super(basedir, version)


### PR DESCRIPTION
I need to use those variables in noe-tests and they are not visible without groovy hacks.