### PR TITLE
[utils] Deprecation of some `isJdk*` methods with more suitable repla…

### DIFF
--- a/core/src/main/groovy/noe/common/utils/Java.groovy
+++ b/core/src/main/groovy/noe/common/utils/Java.groovy
@@ -40,38 +40,104 @@ public class Java {
     "${javaVersion} ${javaVendor} ${javaVmName} ${javaVmInfo}"
   }
 
+  /**
+   * @deprecated since 0.17.2, please use {@link #isJdk6()} instead.
+   * @return true if process is running on JDK 6 AKA JDK 1.6
+   */
   static boolean isJdk16() {
+    return isJdk6()
+  }
+
+  /**
+   * @return true if process is running on JDK 6 AKA JDK 1.6
+   */
+  static boolean isJdk6() {
     return (javaVersion ==~ /^1\.6.*/)
   }
 
+  /**
+   * @deprecated since 0.17.2, please use {@link #isJdk7()} instead.
+   * @return true if process is running on JDK 7 AKA JDK 1.7
+   */
   static  boolean isJdk17() {
+    return isJdk7()
+  }
+
+  /**
+   * @return true if process is running on JDK 7 AKA JDK 1.7
+   */
+  static  boolean isJdk7() {
     return (javaVersion ==~ /^1\.7.*/)
   }
 
+  /**
+   * @deprecated since 0.17.2, please use {@link #isJdk8()} instead.
+   * @return true if process is running on JDK 8 AKA JDK 1.8
+   */
   static boolean isJdk18() {
+    return isJdk8()
+  }
+
+  /**
+   * @return true if process is running on JDK 8 AKA JDK 1.8
+   */
+  static boolean isJdk8() {
     return (javaVersion ==~ /^1\.8.*/)
   }
 
   /**
    * Relates to http://openjdk.java.net/jeps/223
    *
-   * @return true if used Java is version 9
+   * @deprecated since 0.17.2, please use {@link #isJdk9()} instead.
+   * @return true if process is running on JDK 9
    */
   static boolean isJdk19() {
+    return isJdk9()
+  }
+
+  /**
+   * Relates to http://openjdk.java.net/jeps/223
+   *
+   * @return true if process is running on JDK 9
+   */
+  static boolean isJdk9() {
     return (javaVersion ==~ /^9[\.\-\+].*/)
   }
 
+  /**
+   * @return true if process is running on JDK 11
+   */
   static boolean isJdk11() {
     return (javaVersion ==~ /^11[\.\-\+].*/)
   }
 
   /**
-   * Are we running on minimumJDKVersion ?
+   * @return true if process is running on JDK 15
+   */
+  static boolean isJdk15() {
+    return (javaVersion ==~ /^15[\.\-\+].*/)
+  }
+
+  /**
+   * Are we running on minimumJDKVersion ?. This accepts both legacy (1.6, 1.7, etc.)
+   * Java version format and also new one (7, 8, 9, etc.).
    *
    * @param minimumJDKVersion JDK version (example: '1.7')
+   * @deprecated since 0.17.2, please use {@link #isJdkXOrHigher(java.lang.String)} instead.
    * @return true if we are running on minimumJDKVersion or higher
    */
   static boolean isJdk1xOrHigher(String minimumJDKVersion) {
+    return isJdkXOrHigher(minimumJDKVersion)
+  }
+
+  /**
+   * Are we running on minimumJDKVersion ?. This accepts both legacy (1.6, 1.7, etc.)
+   * Java version format and also new one (7, 8, 9, etc.).
+   *
+   * @param minimumJDKVersion JDK version (example: '1.7' or '7')
+   * @return true if we are running on minimumJDKVersion or higher
+   */
+  static boolean isJdkXOrHigher(String minimumJDKVersion) {
     int usedJavaMajorVersion
     int minimumJavaMajorVersion
 

--- a/core/src/test/groovy/noe/common/utils/JavaTest.groovy
+++ b/core/src/test/groovy/noe/common/utils/JavaTest.groovy
@@ -27,55 +27,58 @@ class JavaTest {
   }
 
   @Test
-  void testIsJdk16() {
+  void testIsJdk6() {
     List<String> testedStrings = new LinkedList<>()
     testedStrings.add("1.6.0")
     testedStrings.add("1.6.3")
 
     for (String testedString : testedStrings) {
       setJavaVersion(testedString)
-      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdk16())
-      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk17())
-      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk18())
-      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk19())
+      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdk6())
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk7())
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk8())
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk9())
       Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk11())
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk15())
     }
   }
 
   @Test
-  void testIsJdk17() {
+  void testIsJdk7() {
     List<String> testedStrings = new LinkedList<>()
     testedStrings.add("1.7.0")
     testedStrings.add("1.7.3")
 
     for (String testedString : testedStrings) {
       setJavaVersion(testedString)
-      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdk17())
-      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk16())
-      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk18())
-      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk19())
+      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdk7())
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk6())
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk8())
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk9())
       Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk11())
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk15())
     }
   }
 
   @Test
-  void testIsJdk18() {
+  void testIsJdk8() {
     List<String> testedStrings = new LinkedList<>()
     testedStrings.add("1.8.0")
     testedStrings.add("1.8.3")
 
     for (String testedString : testedStrings) {
       setJavaVersion(testedString)
-      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdk18())
-      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk16())
-      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk17())
-      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk19())
+      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdk8())
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk6())
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk7())
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk9())
       Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk11())
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk15())
     }
   }
 
   @Test
-  void testIsJdk19() {
+  void testIsJdk9() {
     List<String> testedStrings = new LinkedList<>()
     testedStrings.add("9-ea")
     testedStrings.add("9.0.0")
@@ -83,11 +86,12 @@ class JavaTest {
 
     for (String testedString : testedStrings) {
       setJavaVersion(testedString)
-      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdk19())
-      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk16())
-      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk17())
-      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk18())
+      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdk9())
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk6())
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk7())
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk8())
       Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk11())
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk15())
     }
   }
 
@@ -100,16 +104,35 @@ class JavaTest {
 
     for (String testedString : testedStrings) {
       setJavaVersion(testedString)
-      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk19())
-      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk16())
-      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk17())
-      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk18())
       Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdk11())
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk9())
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk6())
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk7())
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk8())
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk15())
     }
   }
 
   @Test
-  void testIsJdk1xOrHigher() {
+  void testIsJdk15() {
+    List<String> testedStrings = new LinkedList<>()
+    testedStrings.add("15.0.1")
+    testedStrings.add("15.1.5")
+    testedStrings.add("15-test")
+
+    for (String testedString : testedStrings) {
+      setJavaVersion(testedString)
+      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdk15())
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk6())
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk7())
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk8())
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk9())
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk11())
+    }
+  }
+
+  @Test
+  void testIsJdkXOrHigher() {
     List<String> testedStrings = new LinkedList<>()
     testedStrings.add("9-ea")
     testedStrings.add("9.0.0")
@@ -117,15 +140,15 @@ class JavaTest {
 
     for (String testedString : testedStrings) {
       setJavaVersion(testedString)
-      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdk1xOrHigher("1.6"))
-      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdk1xOrHigher("1.7"))
-      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdk1xOrHigher("1.8"))
-      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdk1xOrHigher("9"))
-      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdk1xOrHigher("1.9"))
-      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk1xOrHigher("10"))
-      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk1xOrHigher("1.10"))
-      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk1xOrHigher("11"))
-      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk1xOrHigher("1.11"))
+      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdkXOrHigher("1.6"))
+      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdkXOrHigher("1.7"))
+      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdkXOrHigher("1.8"))
+      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdkXOrHigher("9"))
+      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdkXOrHigher("1.9"))
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdkXOrHigher("10"))
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdkXOrHigher("1.10"))
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdkXOrHigher("11"))
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdkXOrHigher("1.11"))
     }
 
     testedStrings = new LinkedList<>()
@@ -134,15 +157,15 @@ class JavaTest {
 
     for (String testedString : testedStrings) {
       setJavaVersion(testedString)
-      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdk1xOrHigher("1.6"))
-      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdk1xOrHigher("1.7"))
-      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk1xOrHigher("1.8"))
-      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk1xOrHigher("9"))
-      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk1xOrHigher("1.9"))
-      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk1xOrHigher("10"))
-      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk1xOrHigher("1.10"))
-      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk1xOrHigher("11"))
-      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdk1xOrHigher("1.11"))
+      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdkXOrHigher("1.6"))
+      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdkXOrHigher("1.7"))
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdkXOrHigher("1.8"))
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdkXOrHigher("9"))
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdkXOrHigher("1.9"))
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdkXOrHigher("10"))
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdkXOrHigher("1.10"))
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdkXOrHigher("11"))
+      Assert.assertFalse("Java version string compared '" + testedString + "'", Java.isJdkXOrHigher("1.11"))
     }
 
     testedStrings = new LinkedList<>()
@@ -151,15 +174,15 @@ class JavaTest {
 
     for (String testedString : testedStrings) {
       setJavaVersion(testedString)
-      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdk1xOrHigher("1.6"))
-      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdk1xOrHigher("1.7"))
-      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdk1xOrHigher("1.8"))
-      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdk1xOrHigher("9"))
-      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdk1xOrHigher("1.9"))
-      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdk1xOrHigher("10"))
-      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdk1xOrHigher("1.10"))
-      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdk1xOrHigher("11"))
-      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdk1xOrHigher("1.11"))
+      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdkXOrHigher("1.6"))
+      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdkXOrHigher("1.7"))
+      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdkXOrHigher("1.8"))
+      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdkXOrHigher("9"))
+      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdkXOrHigher("1.9"))
+      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdkXOrHigher("10"))
+      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdkXOrHigher("1.10"))
+      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdkXOrHigher("11"))
+      Assert.assertTrue("Java version string compared '" + testedString + "'", Java.isJdkXOrHigher("1.11"))
     }
   }
 }


### PR DESCRIPTION
…ces.

Since in a near future we may run into a name collision of the `isJdk*` methods,
this change proposes to deprecate methods with names that include old JDK version
schema (1.6, 1.7, etc.) with introduction of alternatives using a new JDK version
schema (7, 8, 9, etc.).

This also introduces new method that recognizes currently latest java version - JDK15.

@jstefl 