### PR TITLE
AJP connector defaults fixes and typos fixes

### DIFF
--- a/core/src/main/groovy/noe/tomcat/configure/AjpConnectorTomcat.groovy
+++ b/core/src/main/groovy/noe/tomcat/configure/AjpConnectorTomcat.groovy
@@ -19,11 +19,6 @@ public class AjpConnectorTomcat extends ConnectorTomcatAbstract<AjpConnectorTomc
   private String secret
   private String allowedRequestAttributesPattern
 
-  public AjpConnectorTomcat() {
-    port = "0"
-    protocol = "AJP/1.3"
-  }
-
   Boolean getSecretRequired() {
     return secretRequired
   }

--- a/core/src/main/groovy/noe/tomcat/configure/AjpConnectorTomcat.groovy
+++ b/core/src/main/groovy/noe/tomcat/configure/AjpConnectorTomcat.groovy
@@ -19,6 +19,10 @@ public class AjpConnectorTomcat extends ConnectorTomcatAbstract<AjpConnectorTomc
   private String secret
   private String allowedRequestAttributesPattern
 
+  public AjpConnectorTomcat() {
+    protocol = "AJP/1.3"
+  }
+
   Boolean getSecretRequired() {
     return secretRequired
   }

--- a/core/src/main/groovy/noe/tomcat/configure/AjpConnectorTomcat.groovy
+++ b/core/src/main/groovy/noe/tomcat/configure/AjpConnectorTomcat.groovy
@@ -20,6 +20,7 @@ public class AjpConnectorTomcat extends ConnectorTomcatAbstract<AjpConnectorTomc
   private String allowedRequestAttributesPattern
 
   public AjpConnectorTomcat() {
+    port = "0"
     protocol = "AJP/1.3"
   }
 

--- a/core/src/main/groovy/noe/tomcat/configure/ConnectorAttributesTransformer.groovy
+++ b/core/src/main/groovy/noe/tomcat/configure/ConnectorAttributesTransformer.groovy
@@ -169,7 +169,7 @@ class ConnectorAttributesTransformer {
       if (connector.getSslPassword() != null && !connector.getSslPassword().isEmpty()) {
         attributes.put('SSLPassword', connector.getSslPassword())
       }
-      if (connector.getSslEnabledProtocols() != null && connector.getSslEnabledProtocols()) {
+      if (connector.getSslEnabledProtocols() != null) {
         attributes.put('sslEnabledProtocols', connector.getSslEnabledProtocols())
       }
       // ---------------------

--- a/core/src/main/groovy/noe/tomcat/configure/ConnectorConfiguratorTomcat.groovy
+++ b/core/src/main/groovy/noe/tomcat/configure/ConnectorConfiguratorTomcat.groovy
@@ -56,8 +56,6 @@ class ConnectorConfiguratorTomcat {
       createNewConnector(new ConnectorAttributesTransformer(connector).secureHttpConnector())
     }
 
-    defineRedirectPorts(connector.getPort())
-
     return server
   }
 
@@ -79,11 +77,6 @@ class ConnectorConfiguratorTomcat {
     }
 
     return server
-  }
-
-  private void defineRedirectPorts(Integer port) {
-    defineHttpConnector(new NonSecureHttpConnectorTomcat().setRedirectPort(port))
-    defineAjpConnector(new AjpConnectorTomcat().setSecretRequired(false).setRedirectPort(port))
   }
 
   private Node loadExistingHttpConnector() {

--- a/core/src/main/groovy/noe/tomcat/configure/ConnectorConfiguratorTomcat.groovy
+++ b/core/src/main/groovy/noe/tomcat/configure/ConnectorConfiguratorTomcat.groovy
@@ -83,7 +83,7 @@ class ConnectorConfiguratorTomcat {
 
   private void defineRedirectPorts(Integer port) {
     defineHttpConnector(new NonSecureHttpConnectorTomcat().setRedirectPort(port))
-    defineAjpConnector(new AjpConnectorTomcat().setRedirectPort(port))
+    defineAjpConnector(new AjpConnectorTomcat().setSecretRequired(false).setRedirectPort(port))
   }
 
   private Node loadExistingHttpConnector() {

--- a/core/src/main/groovy/noe/tomcat/configure/SecureHttpConnectorTomcat.groovy
+++ b/core/src/main/groovy/noe/tomcat/configure/SecureHttpConnectorTomcat.groovy
@@ -127,7 +127,7 @@ public class SecureHttpConnectorTomcat extends ConnectorTomcatAbstract<SecureHtt
   }
 
   public String getSslCACertificateFile() {
-    return this.sslCertificateFile
+    return this.sslCACertificateFile
   }
 
   public String getSslCertificateKeyFile() {

--- a/testsuite/src/test/groovy/noe/tomcat/BindingsTomcatConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/BindingsTomcatConfiguratorIT.groovy
@@ -262,7 +262,6 @@ abstract class BindingsTomcatConfiguratorIT extends TomcatTestAbstract {
 
     GPathResult Server = new XmlSlurper().parse(new File(tomcat.basedir, "conf/server.xml"))
     assertEquals sslCertificate, Server.Service.Connector.find { isSecuredHttpProtocol(it) }.@SSLCertificateFile.toString()
-    assertEquals sslCertificate, Server.Service.Connector.find { isSecuredHttpProtocol(it) }.@SSLCACertificateFile.toString()
     assertEquals sslCertificateKey, Server.Service.Connector.find { isSecuredHttpProtocol(it) }.@SSLCertificateKeyFile.toString()
     assertEquals keystoreFilePath, Server.Service.Connector.find { isSecuredHttpProtocol(it) }.@keystoreFile.toString()
     assertEquals password, Server.Service.Connector.find { isSecuredHttpProtocol(it) }.@SSLPassword.toString()

--- a/testsuite/src/test/groovy/noe/tomcat/BindingsTomcatConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/BindingsTomcatConfiguratorIT.groovy
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertTrue
 abstract class BindingsTomcatConfiguratorIT extends TomcatTestAbstract {
 
   @Test
-  void updateExistingHttpConnectorAllAttribtuesGivenSuccessExpected() {
+  void updateExistingHttpConnectorAllAttributesGivenSuccessExpected() {
     def onlyOneNonSecureConnector = 1
     Integer testHttpPort = 18080
     def testAddress = "my-test-host"
@@ -108,9 +108,6 @@ abstract class BindingsTomcatConfiguratorIT extends TomcatTestAbstract {
     assertEquals testSSLCertificateKeyFile, Server.Service.Connector.find { isSecure(it) }.@SSLCertificateKeyFile.toString()
     assertEquals testSSLPassword, Server.Service.Connector.find { isSecure(it) }.@SSLPassword.toString()
     assertEquals testScheme, Server.Service.Connector.find { isSecure(it) }.@scheme.toString()
-
-    assertEquals testHttpsPort, Integer.valueOf(Server.Service.Connector.find { isNotSecuredHttpProtocol(it) }.@redirectPort.toString())
-    assertEquals testHttpsPort, Integer.valueOf(Server.Service.Connector.find { isAjpProtocol(it) }.@redirectPort.toString())
   }
 
   @Test
@@ -125,12 +122,12 @@ abstract class BindingsTomcatConfiguratorIT extends TomcatTestAbstract {
 
     new TomcatConfigurator(tomcat)
       .ajpConnector(new AjpConnectorTomcat()
-      .setAddress(testAddress)
-      .setPort(testAjpPort)
-      .setRedirectPort(testRedirectPort)
-      .setMaxThreads(testMaxThreads)
-      .setConnectionTimeout(testConnectionTimeout)
-      .setScheme(testScheme))
+        .setAddress(testAddress)
+        .setPort(testAjpPort)
+        .setRedirectPort(testRedirectPort)
+        .setMaxThreads(testMaxThreads)
+        .setConnectionTimeout(testConnectionTimeout)
+        .setScheme(testScheme))
 
     GPathResult Server = new XmlSlurper().parse(new File(tomcat.basedir, "conf/server.xml"))
     assertEquals onlyOneAjpConnector, Server.Service.Connector.find { isAjpProtocol(it) && !isSecure(it)  }.size()
@@ -140,6 +137,33 @@ abstract class BindingsTomcatConfiguratorIT extends TomcatTestAbstract {
     assertEquals testRedirectPort, Integer.valueOf(Server.Service.Connector.find { isAjpProtocol(it) }.@redirectPort.toString())
     assertEquals testConnectionTimeout, Integer.valueOf(Server.Service.Connector.find { isAjpProtocol(it) }.@connectionTimeout.toString())
     assertEquals testScheme, Server.Service.Connector.find { isAjpProtocol(it) }.@scheme.toString()
+  }
+
+  @Test
+  void createNewAjpConnectorSuccessExpected() {
+    Integer testAjpPort = 18585
+    String testProtocol = "AJP/1.3"
+    Integer testRedirectPort = 18989
+    Boolean testSecretRequired = true
+    String testSecret = "mysecret"
+    String testAllowedRequestAttributesPattern = "customAttributesPattern"
+
+    new TomcatConfigurator(tomcat)
+      .ajpConnector(new AjpConnectorTomcat()
+        .setPort(testAjpPort)
+        .setProtocol(testProtocol)
+        .setRedirectPort(testRedirectPort)
+        .setSecretRequired(testSecretRequired)
+        .setSecret(testSecret)
+        .setAllowedRequestAttributesPattern(testAllowedRequestAttributesPattern))
+
+    GPathResult Server = new XmlSlurper().parse(new File(tomcat.basedir, "conf/server.xml"))
+    assertEquals testAjpPort, Integer.valueOf(Server.Service.Connector.find { isAjpProtocol(it) }.@port.toString())
+    assertEquals testProtocol, Server.Service.Connector.find { isAjpProtocol(it) }.@protocol.toString()
+    assertEquals testRedirectPort, Integer.valueOf(Server.Service.Connector.find { isAjpProtocol(it) }.@redirectPort.toString())
+    assertEquals testSecretRequired, Boolean.valueOf(Server.Service.Connector.find { isAjpProtocol(it) }.@secretRequired.toString())
+    assertEquals testSecret, Server.Service.Connector.find { isAjpProtocol(it) }.@secret.toString()
+    assertEquals testAllowedRequestAttributesPattern, Server.Service.Connector.find { isAjpProtocol(it) }.@allowedRequestAttributesPattern.toString()
   }
 
   @Test
@@ -156,6 +180,33 @@ abstract class BindingsTomcatConfiguratorIT extends TomcatTestAbstract {
     assertEquals testAjpPort, Integer.valueOf(Server.Service.Connector.find { isAjpProtocol(it) }.@port.toString())
     assertEquals Tomcat.DEFAULT_HTTPS_PORT, Integer.valueOf(Server.Service.Connector.find { isAjpProtocol(it) }.@redirectPort.toString())
     assertEquals defAttributesCountOfAjpConnector, Server.Service.Connector.find { isAjpProtocol(it) }.attributes().size()
+  }
+
+  @Test
+  void createNewHttpConnectorSuccessExpected() {
+    Integer testAjpPort = 18585
+    String testProtocol = "AJP/1.3"
+    Integer testRedirectPort = 18989
+    Boolean testSecretRequired = true
+    String testSecret = "mysecret"
+    String testAllowedRequestAttributesPattern = "customAttributesPattern"
+
+    new TomcatConfigurator(tomcat)
+      .ajpConnector(new AjpConnectorTomcat()
+        .setPort(testAjpPort)
+        .setProtocol(testProtocol)
+        .setRedirectPort(testRedirectPort)
+        .setSecretRequired(testSecretRequired)
+        .setSecret(testSecret)
+        .setAllowedRequestAttributesPattern(testAllowedRequestAttributesPattern))
+
+    GPathResult Server = new XmlSlurper().parse(new File(tomcat.basedir, "conf/server.xml"))
+    assertEquals testAjpPort, Integer.valueOf(Server.Service.Connector.find { isAjpProtocol(it) }.@port.toString())
+    assertEquals testProtocol, Server.Service.Connector.find { isAjpProtocol(it) }.@protocol.toString()
+    assertEquals testRedirectPort, Server.Service.Connector.find { isAjpProtocol(it) }.@redirectPort.toString()
+    assertEquals testSecretRequired, Boolean.valueOf(Server.Service.Connector.find { isAjpProtocol(it) }.@secretRequired.toString())
+    assertEquals testSecret, Server.Service.Connector.find { isAjpProtocol(it) }.@secret.toString()
+    assertEquals testAllowedRequestAttributesPattern, Server.Service.Connector.find { isAjpProtocol(it) }.@allowedRequestAttributesPattern.toString()
   }
 
   @Test
@@ -204,7 +255,7 @@ abstract class BindingsTomcatConfiguratorIT extends TomcatTestAbstract {
     Integer shiftedAjpPort = 18009
 
     new TomcatConfigurator(tomcat)
-        .portOffset(testOffset)
+      .portOffset(testOffset)
 
     GPathResult Server = new XmlSlurper().parse(new File(tomcat.basedir, "conf/server.xml"))
     assertEquals shiftedHttpPort, Integer.valueOf(Server.Service.Connector.find { isNotSecuredHttpProtocol(it) }.@port.toString())
@@ -219,18 +270,16 @@ abstract class BindingsTomcatConfiguratorIT extends TomcatTestAbstract {
     int testOffset = 10000
     Integer testHttpsPort = 18443
 
-    new TomcatConfigurator(tomcat)
+    TomcatConfigurator tconf = new TomcatConfigurator(tomcat)
       .httpsConnector(new SecureHttpConnectorTomcat().setPort(testHttpsPort))
       .portOffset(testOffset)
 
     GPathResult Server = new XmlSlurper().parse(new File(tomcat.basedir, "conf/server.xml"))
-    assertEquals testHttpsPort + testOffset, Integer.valueOf(Server.Service.Connector.find { isNotSecuredHttpProtocol(it) }.@redirectPort.toString())
-    assertEquals testHttpsPort + testOffset, Integer.valueOf(Server.Service.Connector.find { isAjpProtocol(it) }.@redirectPort.toString())
     assertEquals testHttpsPort + testOffset, Integer.valueOf(Server.Service.Connector.find { isSecure(it) }.@port.toString())
   }
 
   @Test
-  void shiftPortAndSetHttpsPortDefaltServerXmlChangeExpected() {
+  void shiftPortAndSetHttpsPortDefaultServerXmlChangeExpected() {
     int testOffset = 10000
     Integer testHttpsPort = 18443
 
@@ -239,8 +288,6 @@ abstract class BindingsTomcatConfiguratorIT extends TomcatTestAbstract {
       .httpsConnector(new SecureHttpConnectorTomcat().setPort(testHttpsPort))
 
     GPathResult Server = new XmlSlurper().parse(new File(tomcat.basedir, "conf/server.xml"))
-    assertEquals testHttpsPort, Integer.valueOf(Server.Service.Connector.find { isNotSecuredHttpProtocol(it) }.@redirectPort.toString())
-    assertEquals testHttpsPort, Integer.valueOf(Server.Service.Connector.find { isAjpProtocol(it) }.@redirectPort.toString())
     assertEquals testHttpsPort, Integer.valueOf(Server.Service.Connector.find { isSecuredHttpProtocol(it) }.@port.toString())
     assertEquals Tomcat.DEFAULT_HTTP_PORT + testOffset, Integer.valueOf(Server.Service.Connector.find { isNotSecuredHttpProtocol(it) }.@port.toString())
   }

--- a/testsuite/src/test/groovy/noe/tomcat/BindingsTomcatConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/BindingsTomcatConfiguratorIT.groovy
@@ -203,7 +203,7 @@ abstract class BindingsTomcatConfiguratorIT extends TomcatTestAbstract {
     GPathResult Server = new XmlSlurper().parse(new File(tomcat.basedir, "conf/server.xml"))
     assertEquals testAjpPort, Integer.valueOf(Server.Service.Connector.find { isAjpProtocol(it) }.@port.toString())
     assertEquals testProtocol, Server.Service.Connector.find { isAjpProtocol(it) }.@protocol.toString()
-    assertEquals testRedirectPort, Server.Service.Connector.find { isAjpProtocol(it) }.@redirectPort.toString()
+    assertEquals testRedirectPort, Integer.valueOf(Server.Service.Connector.find { isAjpProtocol(it) }.@redirectPort.toString())
     assertEquals testSecretRequired, Boolean.valueOf(Server.Service.Connector.find { isAjpProtocol(it) }.@secretRequired.toString())
     assertEquals testSecret, Server.Service.Connector.find { isAjpProtocol(it) }.@secret.toString()
     assertEquals testAllowedRequestAttributesPattern, Server.Service.Connector.find { isAjpProtocol(it) }.@allowedRequestAttributesPattern.toString()


### PR DESCRIPTION
I made one typo mistake during previous push.It needs to be fixed.
Also during refactoring noe-tests based on noe-core refactoring AJP connector is failing (with portOutOfIndex error) during tomcat start as it has no specified port. Even it is specified, if secretRequired is absent the default is true.So i set it during httpsSecure setting to false.If the user/tester wants to change it, he can change it afterwards with specific AJP connector update

@jstefl FYI