### PR TITLE
added default modcluster.conf update to manage new naming convention

### DIFF
--- a/core/src/main/groovy/noe/common/DefaultProperties.groovy
+++ b/core/src/main/groovy/noe/common/DefaultProperties.groovy
@@ -2,6 +2,7 @@ package noe.common
 
 import noe.common.utils.Library
 import noe.common.utils.OpenSslVersion
+import noe.common.utils.Platform
 import noe.common.utils.Version
 /**
  *
@@ -127,4 +128,8 @@ class DefaultProperties {
   public static final String MODCLUSTER_MCAST_PORT = Library.getUniversalProperty('modcluster.mcast.port', '23364')
   public static final String UDP_MCAST_ADDRESS = Library.getUniversalProperty('udp.mcast.address', Library.getUniversalProperty("MCAST_ADDR", '228.11.11.11'))
   public static final String JGROUPS_MCAST_PORT = Library.getUniversalProperty('jgroups.mcast.port', Library.getUniversalProperty("MCAST_PORT", '45688'))
+
+  // Added to allow for the new naming convention used in RHEL9
+  static final String MOD_CLUSTER_CONFIG_FILE = new Platform().isRHEL9() ? Library.getUniversalProperty('mod.proxy.cluster.config.file', "mod_proxy_cluster.conf") : Library.getUniversalProperty('modcluster.config.file', "mod_cluster.conf")
+  static final String MOD_PROXY_CLUSTER_CONFIG_FILE = MOD_CLUSTER_CONFIG_FILE
 }


### PR DESCRIPTION
As Mod_Cluster is changing it's naming convention it has impacts on the configuration file, so mod_cluster.conf will become mod_proxy_cluster.conf. 
This modification adds the possability to `automatically` swap depending on OS, thus providing a backwards compatibility.   