### PR TITLE
[JDK17] Update working with PIDs to be compatible with JDK9+

### DIFF
--- a/core/src/main/groovy/noe/common/newcmd/KillCmdBuilder.java
+++ b/core/src/main/groovy/noe/common/newcmd/KillCmdBuilder.java
@@ -67,8 +67,8 @@ public class KillCmdBuilder extends CmdBuilder<KillCmdBuilder> {
      * @param processIds  process ids to kill as integer
      * @return  this
      */
-    public KillCmdBuilder addProcessId(final int... processIds) {
-        for(int processId: processIds) {
+    public KillCmdBuilder addProcessId(final long... processIds) {
+        for(long processId: processIds) {
             String stringProcessId = String.valueOf(processId);
             addProcessId(stringProcessId);
         }

--- a/core/src/main/groovy/noe/common/newcmd/ListProcess.java
+++ b/core/src/main/groovy/noe/common/newcmd/ListProcess.java
@@ -180,7 +180,7 @@ public class ListProcess {
      * @return list of map where information about processes in the tree is saved
      * @throws IOException when not possible to run the process list command
      */
-    public List<Map<PsCmdFormat, String>> listProcessTree(final int processId) throws IOException {
+    public List<Map<PsCmdFormat, String>> listProcessTree(final long processId) throws IOException {
         ListProcessData data = listAll(PsCmdFormat.PROCESS_ID, PsCmdFormat.PARENT_PROCESS_ID, PsCmdFormat.COMMAND);
 
         ImmutableList.Builder<Map<PsCmdFormat, String>> psTreeBuilder = ImmutableList.<Map<PsCmdFormat, String>>builder();
@@ -196,7 +196,7 @@ public class ListProcess {
 
         List<String> listOfIdsToCheck = new ArrayList<String>();
         List<String> listOfIdsInProgress = new ArrayList<String>();
-        listOfIdsToCheck.add(Integer.toString(processId));
+        listOfIdsToCheck.add(Long.toString(processId));
 
         // passing through ps results to get all the process three (filter returns filtered copy of data)
         while (!listOfIdsToCheck.isEmpty()) {
@@ -246,7 +246,7 @@ public class ListProcess {
      * @return process info
      * @throws IOException when some error on execution happens
      */
-    public String printProcessInfo(final int processId) throws IOException, InterruptedException {
+    public String printProcessInfo(final long processId) throws IOException, InterruptedException {
         CmdBuilder<SimpleCmdBuilder> builder = new CmdBuilder<SimpleCmdBuilder>("");
         if (platform.isWindows()) {
             builder.setBaseCommand("wmic");

--- a/core/src/main/groovy/noe/common/newcmd/ListProcessData.java
+++ b/core/src/main/groovy/noe/common/newcmd/ListProcessData.java
@@ -116,7 +116,7 @@ public class ListProcessData {
      * @param processId  process id that should be search in data
      * @return info on data
      */
-    public Map<PsCmdFormat,String> get(final int processId) {
+    public Map<PsCmdFormat,String> get(final long processId) {
         String processIdAsString = String.valueOf(processId);
         if(listing.get(processIdAsString) == null) {
             return null;
@@ -328,14 +328,35 @@ public class ListProcessData {
                     int2 = Integer.valueOf(str2);
                 } catch (NumberFormatException nfe) {
                     // if string from left is not possible to convert to int
-                    // then in case of right is not possible to convert do string comparision
-                    // otherwise left was possible to convert but right is not posible to convert (returns 1)
+                    // then in case of right is not possible to convert do string comparison
+                    // otherwise left was possible to convert but right is not possible to convert (returns 1)
                     return int1error ? str1.compareTo(str2) : 1;
                 }
                 // if string from left is not possible to convert to int
                 // then we know that right was converted fine and we return -1
-                // otherwise both were converted without problem and returning integer comparision
+                // otherwise both were converted without problem and returning integer comparison
                 return int1error ? -1 : int1.compareTo(int2);
+            }
+            if(dataType.isInstance(Long.valueOf(0))) {
+                boolean long1error = false;
+                Long long1 = null, long2 = null;
+                try {
+                    long1 = Long.valueOf(str1);
+                } catch (NumberFormatException nfe) {
+                    long1error = true;
+                }
+                try {
+                    long2 = Long.valueOf(str2);
+                } catch (NumberFormatException nfe) {
+                    // if string from left is not possible to convert to long
+                    // then in case of right is not possible to convert do string comparison
+                    // otherwise left was possible to convert but right is not possible to convert (returns 1)
+                    return long1error ? str1.compareTo(str2) : 1;
+                }
+                // if string from left is not possible to convert to long
+                // then we know that right was converted fine and we return -1
+                // otherwise both were converted without problem and returning integer comparison
+                return long1error ? -1 : long1.compareTo(long2);
             }
             return str1.compareTo(str2);
         }

--- a/core/src/main/groovy/noe/common/newcmd/PsCmdFormat.java
+++ b/core/src/main/groovy/noe/common/newcmd/PsCmdFormat.java
@@ -27,11 +27,11 @@ public enum PsCmdFormat {
     /**
      * Id of process.
      */
-    PROCESS_ID(false, Integer.class),
+    PROCESS_ID(false, Long.class),
     /**
      * Pid of process parent.
      */
-    PARENT_PROCESS_ID(false, Integer.class),
+    PARENT_PROCESS_ID(false, Long.class),
     /**
      * Priority (nice) of the process.
      */

--- a/core/src/main/groovy/noe/common/utils/processid/ProcessUtils.groovy
+++ b/core/src/main/groovy/noe/common/utils/processid/ProcessUtils.groovy
@@ -1,9 +1,11 @@
 package noe.common.utils.processid;
 
 import com.sun.jna.Pointer;
+import noe.common.utils.Java;
 import noe.common.utils.Platform;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 
 /**
  * Util class that helps getting different information from Process object.
@@ -11,10 +13,14 @@ import java.lang.reflect.Field;
  * Borrowed implementation of methods for retrieving processId from Process class from other Red Hat test suites
  */
 public final class ProcessUtils {
-    public static final int UNDEFINED_PROCESS_ID = -1;
+    public static final long UNDEFINED_PROCESS_ID = Long.MIN_VALUE;
     private static final Platform platform = new Platform();
 
-    public static int getProcessId(final Process process) {
+    public static long getProcessId(final Process process) {
+        if (Java.isJdkXOrHigher("9")) {
+            return getProcessIdJava9AndNewer(process);
+        }
+
         if (platform.isWindows()) {
             return getWindowsProcessId(process);
         } else {
@@ -28,12 +34,10 @@ public final class ProcessUtils {
      * @param process running process
      * @return process id
      */
-    public static int getWindowsProcessId(final Process process) {
-        int processId = UNDEFINED_PROCESS_ID;
-
+    public static long getWindowsProcessId(final Process process) {
         if (process.getClass().getName().equals("java.lang.Win32Process")
                 || process.getClass().getName().equals("java.lang.ProcessImpl")) {
-            /* determine the process id on windows plattforms */
+            /* determine the process id on windows platforms */
             try {
                 Field f = process.getClass().getDeclaredField("handle");
                 f.setAccessible(true);
@@ -42,12 +46,12 @@ public final class ProcessUtils {
                 Kernel32 kernel = Kernel32.INSTANCE;
                 W32API.HANDLE handle = new W32API.HANDLE();
                 handle.setPointer(Pointer.createConstant(handl));
-                processId = kernel.GetProcessId(handle);
+                return kernel.GetProcessId(handle);
             } catch (Throwable e) {
-                throw new RuntimeException("Not able to get process id on Windows " + processId, e);
+                throw new RuntimeException("Not able to get process id of process " + process, e);
             }
         }
-        return processId;
+        return UNDEFINED_PROCESS_ID;
     }
 
     /**
@@ -56,8 +60,8 @@ public final class ProcessUtils {
      * @param process running process
      * @return process id
      */
-    public static int getUnixProcessId(final Process process) {
-        int processId = UNDEFINED_PROCESS_ID;
+    public static long getUnixProcessId(final Process process) {
+        long processId = UNDEFINED_PROCESS_ID;
 
         if (process.getClass().getName().equals("java.lang.UNIXProcess")
                 || process.getClass().getName().equals("java.lang.ProcessImpl")) {
@@ -65,14 +69,25 @@ public final class ProcessUtils {
             try {
                 Field f = process.getClass().getDeclaredField("pid");
                 f.setAccessible(true);
-                processId = f.getInt(process);
+                processId = f.getLong(process);
             } catch (Throwable e) {
-                throw new RuntimeException("Not able to get process id on Unix " + processId, e);
+                throw new RuntimeException("Not able to get process id of process " + process, e);
             }
         }
 
         return processId;
     }
+
+    private static long getProcessIdJava9AndNewer(final Process process) {
+        try {
+            // although the method is public, we are using reflection to execute it to be able to compile on JDK8
+            // as the method exists only in JDK9+
+            return (long) Process.class.getDeclaredMethod("pid").invoke(process);
+        } catch (SecurityException | NoSuchMethodException e) {
+            throw new RuntimeException("Not able to get process id of process " + process, e);
+        }
+    }
+
 
     /**
      * Checks whether process is alive (still running) or not.

--- a/core/src/main/groovy/noe/ews/server/httpd/HttpdRpm.groovy
+++ b/core/src/main/groovy/noe/ews/server/httpd/HttpdRpm.groovy
@@ -64,13 +64,13 @@ class HttpdRpm extends Httpd {
     return new File("/var/run/${serviceName}/${serviceName}.pid")
   }
 
-  Integer extractPid() {
+  Long extractPid() {
     def pidAsStr = new ByteArrayOutputStream()
     if (Cmd.executeCommandRedirectIO("sudo cat ${getPidFile()}", null, null, pidAsStr, System.err) == 0) {
       pidAsStr = pidAsStr.toString()
       pidAsStr = pidAsStr.trim()
       pidAsStr = pidAsStr.replaceAll('"', '')
-      pid = Integer.valueOf(pidAsStr)
+      pid = Long.valueOf(pidAsStr)
 
       return pid
     } else {

--- a/core/src/main/groovy/noe/ews/server/tomcat/TomcatSolaris.groovy
+++ b/core/src/main/groovy/noe/ews/server/tomcat/TomcatSolaris.groovy
@@ -101,10 +101,10 @@ class TomcatSolaris extends Tomcat {
     return result
   }
 
-  Integer extractPid() {
+  Long extractPid() {
     try {
       String pidFromFile = JBFile.read(pidFile).trim().replaceAll('"', '')
-      pid = Integer.valueOf(pidFromFile)
+      pid = Long.valueOf(pidFromFile)
     } catch (e) {
       pid = super.extractPid()
     }

--- a/core/src/main/groovy/noe/rhel/server/httpd/HttpdBaseOS.groovy
+++ b/core/src/main/groovy/noe/rhel/server/httpd/HttpdBaseOS.groovy
@@ -64,8 +64,8 @@ class HttpdBaseOS extends Httpd {
     return new File("/var/run/${serviceName}/${serviceName}.pid")
   }
 
-  Integer extractPid() {
-    int pid
+  Long extractPid() {
+    long pid
     try {
       String pidFromFile = JBFile.read(pidFile).trim().replaceAll('"','')
       pid = Integer.valueOf(pidFromFile)

--- a/core/src/main/groovy/noe/rhel/server/tomcat/TomcatRpm.groovy
+++ b/core/src/main/groovy/noe/rhel/server/tomcat/TomcatRpm.groovy
@@ -81,7 +81,7 @@ class TomcatRpm extends Tomcat {
         // Try to search for 'CATALINA_PID' in file content
         def m = fileText =~ /CATALINA_PID=(.*)/
 
-        // Get value - actually we want last occurence of CATALINA_PID as that
+        // Get value - actually we want last occurrence of CATALINA_PID as that
         // possibly rewrites all preceding occurrences.
         for (int i = m.size()-1; i >= 0; i--) {
           if (m[i].size() > 1) {
@@ -108,12 +108,12 @@ class TomcatRpm extends Tomcat {
     }
   }
 
-  Integer extractPid() {
+  Long extractPid() {
     try {
       def pidAsStr = pidFile.text
       pidAsStr = pidAsStr.trim()
       pidAsStr = pidAsStr.replaceAll('"', '')
-      pid = Integer.valueOf(pidAsStr)
+      pid = Long.valueOf(pidAsStr)
     }
     catch (e) {
       log.debug("PID file is not accessible. But continuing ...")

--- a/core/src/main/groovy/noe/server/Fuse.groovy
+++ b/core/src/main/groovy/noe/server/Fuse.groovy
@@ -76,7 +76,7 @@ public class Fuse extends ServerAbstract {
   }
 
   @Override
-  Integer extractPid() {
+  Long extractPid() {
     File instancePropsFile = new File(basedir, "instances${platform.sep}instance.properties")
     if (instancePropsFile.exists()) {
       int serverPid = retrievePidFromInstancesPropsFile(instancePropsFile)

--- a/core/src/main/groovy/noe/server/Httpd.groovy
+++ b/core/src/main/groovy/noe/server/Httpd.groovy
@@ -372,7 +372,7 @@ abstract class Httpd extends ServerAbstract {
     }
   }
 
-  Integer extractPid() {
+  Long extractPid() {
     String stringPid = null
     File pidFile = getPidFile()
     if (!pidFile.exists()) {
@@ -383,7 +383,7 @@ abstract class Httpd extends ServerAbstract {
     if ( stringPid.isEmpty() ) {
       throw new RuntimeException("Extraction of httpd PID went wrong, ${pidFile} is empty")
     }
-    pid = stringPid.toInteger()
+    pid = stringPid.toLong()
     return pid
   }
 

--- a/core/src/main/groovy/noe/server/ServerAbstract.groovy
+++ b/core/src/main/groovy/noe/server/ServerAbstract.groovy
@@ -47,7 +47,7 @@ abstract class ServerAbstract implements IApp {
 
   // process management
   Process process // running server process (if was started on background)
-  Integer pid // process pid
+  Long pid // process pid
   String processCode // for process identification
   String runAs // under who user run the process, empty value means actual user
   String runContext // commandline context
@@ -216,8 +216,8 @@ abstract class ServerAbstract implements IApp {
    *  - server run with some unique id (processCode) 
    *  - running process is filtered by this id 
    */
-  Integer extractPid() {
-    Integer extractedPid = null
+  Long extractPid() {
+    Long extractedPid = null
     if (process != null && ProcessUtils.isProcAlive(process)) {
       log.debug("Process is running, trying to extract pid directly from it")
       extractedPid = ProcessUtils.getProcessId(process)


### PR DESCRIPTION
Even though this change doesn't makes this project able to compile with
JDK9+ it at least adds a possibility to utilize its classes and methods
in some other projects with regards the work with PIDs running on JDK9+.

We are using a "hack" to call the method for PID retrieval by reflection
because it is only present in Java 9 and newer. That allows us to still
compile this code on older JDKs.

As a consequence the pid number changed from integer to long so we had
to change it everywhere. Dependent projects should update their usages
appropriately to long too, although since long -> integer is just about
the precision loss issue and I am not aware of any platform (from those
we use) that uses long instead of integer for their PIDs, it shouldn't
be a big issue.

This is slightly related to what is being prepared here #120.