### PR TITLE
Github does not allow anonymous git protocol, so testsuite was failing

### DIFF
--- a/core/src/test/groovy/noe/common/utils/GitUtilsTest.groovy
+++ b/core/src/test/groovy/noe/common/utils/GitUtilsTest.groovy
@@ -8,7 +8,7 @@ import org.junit.Test
 
 class GitUtilsTest {
 
-    private static final String TEST_REPO_URL = "git://github.com/schacon/grit.git"
+    private static final String TEST_REPO_URL = "https://github.com/schacon/grit.git"
 
     private static File TEST_DIR
 


### PR DESCRIPTION
Testsuite fails as repository can't be cloned. Switch to https protocol for test to pass