### PR TITLE
Add warning for SHA1PRNG with openjdk-17 on FIPS environment

### DIFF
--- a/core/src/main/groovy/noe/server/Tomcat.groovy
+++ b/core/src/main/groovy/noe/server/Tomcat.groovy
@@ -198,6 +198,7 @@ class Tomcat extends ServerAbstract implements WorkerServer {
     final List<String> defaultFilteredLines = platform.isFips() ? Arrays.asList(
             "Creation of SecureRandom instance for session ID generation using \\[.*\\] took \\[",
             "Exception initializing random number generator using algorithm \\[SHA1PRNG\\]",
+            "WARNING [main] org.apache.catalina.util.SessionIdGeneratorBase.<clinit> The default SHA1PRNG algorithm for SecureRandom is not supported by this JVM. Using the platform default.",
             "ErrorReportValve\\.java"
     ) : Arrays.asList(
             "Creation of SecureRandom instance for session ID generation using \\[.*\\] took \\[")


### PR DESCRIPTION
As the fix of [tomcat bz#65806](https://bz.apache.org/bugzilla/show_bug.cgi?id=65806), the Exceptions thrown by java-17 on FIPS platforms when SHA1PRNG is used as default in tomcat went from SEVERE to WARNING, those warnings are causing failures in  testsuites that check for warnings. Add the warning to the list of ignored ones.