### PR TITLE
Let's allow to enable/disable JavaScript support in verifyUrl().

### DIFF
--- a/core/src/main/groovy/noe/common/utils/VerifyURLBuilder.groovy
+++ b/core/src/main/groovy/noe/common/utils/VerifyURLBuilder.groovy
@@ -24,6 +24,7 @@ public final class VerifyURLBuilder {
   private String reqKey = ""
   private String reqValue = ""
   private WebClient webClient = null
+  private boolean enableJavaScript = true
   private boolean clearWebClientCache = false
   private boolean reThrowAnyException = false
   private boolean contentAsRegex = false
@@ -144,6 +145,14 @@ public final class VerifyURLBuilder {
   }
 
   /**
+   *  Enable/disable JavaScript support in WebClient instance.
+   */
+  VerifyURLBuilder enableJavaScript(boolean enableJS) {
+    this.enableJavaScript = enableJS
+    return this
+  }
+
+  /**
    * Explicitly clear WebClient's cache?
    */
   VerifyURLBuilder clearWebClientCache(boolean clearWebClientCache) {
@@ -258,6 +267,7 @@ public final class VerifyURLBuilder {
     // mbabacek: We need 404, 403 and others as well :-)
     webClient.getOptions().setThrowExceptionOnFailingStatusCode(false)
     webClient.getOptions().setRedirectEnabled(allowRedirects)
+    webClient.getOptions().setJavaScriptEnabled(enableJavaScript)
     if (webConnectionTimeout != null) {
       webClient.getOptions().setTimeout(webConnectionTimeout)
     }

--- a/core/src/main/groovy/noe/server/AS7.groovy
+++ b/core/src/main/groovy/noe/server/AS7.groovy
@@ -313,6 +313,7 @@ class AS7 extends ServerAbstract implements WorkerServer {
         if (!VerifyURLBuilder.verifyURL {
           it.url super.getUrl('', true)
           it.code 200
+          it.enableJavaScript false
           it.content WELCOME_ROOT_CONTEXT
           it.timeout timeout * 1000
           it.webClient webClient
@@ -328,6 +329,7 @@ class AS7 extends ServerAbstract implements WorkerServer {
       if (!VerifyURLBuilder.verifyURL {
         it.url super.getUrl('', false, port)
         it.code 200
+        it.enableJavaScript false
         it.content WELCOME_ROOT_CONTEXT
         it.timeout timeout*1000
         it.swallowIOExceptions true


### PR DESCRIPTION
With JavaScript allowed (default behavior) we started to see following
errors [4] with WildFly 26+. There are probably two reason for these:

1/ WebClient default instance doesn't utilize all the possible features
what todays browsers have with regards to JavaScript. Workaround may be
to use `new WebClient(BrowserVersion.FIREFOX_XX) as described in [1,2].

2/ We use quite old version of `htmlunit` project for this [3]. Reason
is that this version is the last with JDK6 support. Once we move
`noe-core` to newer JDK, we can update this tool too.

Anyway, disabling JavaScript support in WebClient instance mitigates the
errors we observe so this change adds a possibility to disable it.
Change only affects AS7 (WildFly + JBoss EAP), and I believe these
never needed that so it should be safe.

[1] http://vsingleton.blogspot.com/2015/11/cannot-find-function-addeventlistener.html
[2] https://sourceforge.net/p/htmlunit/bugs/1615/
[3] https://github.com/HtmlUnit/htmlunit
[4] Observed errors:

```
2022-07-03 22:40:22.632 ERROR noe.common.utils.VerifyURLBuilder: verifyUrl() - problem with handling response text, exception detected
com.gargoylesoftware.htmlunit.ScriptException: TypeError: Cannot find function addEventListener in object [object HTMLDocument]. (http://127.0.0.1:9990/console/js/external.min.js#7)
	at com.gargoylesoftware.htmlunit.javascript.JavaScriptEngine$HtmlUnitContextAction.run(JavaScriptEngine.java:705) ~[htmlunit-2.15.jar:2.15]
	at net.sourceforge.htmlunit.corejs.javascript.Context.call(Context.java:620) ~[htmlunit-core-js-2.15.jar:na]
	at net.sourceforge.htmlunit.corejs.javascript.ContextFactory.call(ContextFactory.java:513) ~[htmlunit-core-js-2.15.jar:na]
	at com.gargoylesoftware.htmlunit.javascript.JavaScriptEngine.execute(JavaScriptEngine.java:591) ~[htmlunit-2.15.jar:2.15]
        ...
Caused by: net.sourceforge.htmlunit.corejs.javascript.EcmaError: TypeError: Cannot find function addEventListener in object [object HTMLDocument]. (http://127.0.0.1:9990/console/js/external.min.js#7)
	at net.sourceforge.htmlunit.corejs.javascript.ScriptRuntime.constructError(ScriptRuntime.java:3629) ~[htmlunit-core-js-2.15.jar:na]
	at net.sourceforge.htmlunit.corejs.javascript.ScriptRuntime.constructError(ScriptRuntime.java:3613) ~[htmlunit-core-js-2.15.jar:na]
	at net.sourceforge.htmlunit.corejs.javascript.ScriptRuntime.typeError(ScriptRuntime.java:3634) ~[htmlunit-core-js-2.15.jar:na]
	at net.sourceforge.htmlunit.corejs.javascript.ScriptRuntime.typeError2(ScriptRuntime.java:3650) ~[htmlunit-core-js-2.15.jar:na]
	...
```