### PR TITLE
Places where zip file names for RHEL9 are not set

### DIFF
--- a/core/src/main/groovy/noe/common/utils/PlatformSuffixHelper.groovy
+++ b/core/src/main/groovy/noe/common/utils/PlatformSuffixHelper.groovy
@@ -36,6 +36,7 @@ class PlatformSuffixHelper {
       else if (platform.isRHEL6()) platformName += "RHEL6-"
       else if (platform.isRHEL7()) platformName += "RHEL7-"
       else if (platform.isRHEL8()) platformName += "RHEL8-"
+      else if (platform.isRHEL9()) platformName += "RHEL9-"
       if (platform.isX86()) {
         platformName += "i686"
       } else if (platform.isX64()) {
@@ -113,6 +114,7 @@ class PlatformSuffixHelper {
       else if (platform.isRHEL6()) platformName += "RHEL6-"
       else if (platform.isRHEL7()) platformName += "RHEL7-"
       else if (platform.isRHEL8()) platformName += "RHEL8-"
+      else if (platform.isRHEL9()) platformName += "RHEL9-"
       if (platform.isX86()) {
         platformName += "i386"
       } else if (platform.isX64()) {

--- a/core/src/main/groovy/noe/ews/utils/EwsUtils.groovy
+++ b/core/src/main/groovy/noe/ews/utils/EwsUtils.groovy
@@ -583,6 +583,7 @@ class EwsUtils extends InstallerUtils {
       else if (platform.isRHEL6()) fn += "${version}-RHEL6-"
       else if (platform.isRHEL7()) fn += "${version}-RHEL7-"
       else if (platform.isRHEL8()) fn += "${version}-RHEL8-"
+      else if (platform.isRHEL9()) fn += "${version}-RHEL9-"
       if (platform.isX86()) {
         fn += "i386"
       } else if (platform.isX64()) {

--- a/core/src/test/groovy/noe/tomcat/configure/envars/EnvVarsFileFactoryTest.groovy
+++ b/core/src/test/groovy/noe/tomcat/configure/envars/EnvVarsFileFactoryTest.groovy
@@ -53,7 +53,7 @@ class EnvVarsFileFactoryTest {
     ] as RpmTomcatEnvVarsFileFactory.RpmRun)
 
     String tomcatServicePath
-    if (platform.isRHEL8()) {
+    if (platform.isRHEL8() || platform.isRHEL9()) {
       tomcatServicePath = "/etc/opt/rh/scls/jws5/sysconfig/tomcat"
     } else {
       tomcatServicePath = "/etc/opt/rh/jws5/sysconfig/tomcat"


### PR DESCRIPTION
I found a number of places where isPlatform("RHEL8") is used but not isPlatform("RHEL9"), making the test fail to find the zip package file.

One of them was making fail some tests in our acceptance-pipeline