### PR TITLE
letsSleep uses a factor, not real time

### DIFF
--- a/core/src/main/groovy/noe/common/utils/Library.groovy
+++ b/core/src/main/groovy/noe/common/utils/Library.groovy
@@ -211,7 +211,7 @@ class Library {
         socket?.close()
       }
       Library.letsSleep(1000)
-      now += 1000
+      now += new Date().getTime()
     }
     // still port not ready, failing
     return false
@@ -257,7 +257,7 @@ class Library {
         socket?.close()
       }
       Library.letsSleep(1000)
-      now += 1000
+      now += new Date().getTime()
     }
     // still port opened
     log.trace("Returning, still opened :-(")


### PR DESCRIPTION
A few missing changes, all others were already
adapted and didn't assume that the slept time
was the one used for the call.