### PR TITLE
Adapt integration testing to run in RHEL8 and beyond

### DIFF
--- a/core/src/main/groovy/noe/common/DefaultProperties.groovy
+++ b/core/src/main/groovy/noe/common/DefaultProperties.groovy
@@ -141,4 +141,6 @@ class DefaultProperties {
   public static final String MOD_PROXY_CLUSTER_CONFIG_FILE = MOD_CLUSTER_CONFIG_FILE
   // Making the conf directory configurable
   public static final String CONF_DIRECTORY = Library.getUniversalProperty('jbcs.conf.d.directory', "conf.d")
+  public static final String CONF_MODULES_DIRECTORY = Library.getUniversalProperty('jbcs.conf.modules.d.directory', "conf.modules.d")
+
 }

--- a/core/src/main/groovy/noe/ews/server/httpd/Httpd24Rpm.groovy
+++ b/core/src/main/groovy/noe/ews/server/httpd/Httpd24Rpm.groovy
@@ -33,6 +33,7 @@ class Httpd24Rpm extends HttpdRpm {
     this.apachectl = ['/usr/sbin/apachectl24']
     this.deploymentPath = "/var/www/${serviceName}"
     this.confDeploymentPath = this.basedir + "/${DefaultProperties.CONF_DIRECTORY}"
+    this.confModulesDeploymentPath = this.basedir + "/${DefaultProperties.CONF_MODULES_DIRECTORY}"
     this.cgiDeploymentPath = this.deploymentPath + "/cgi-bin"
     this.abPath = "/usr/bin/ab24"
     this.htdbmPath = "/usr/bin/htdbm24"

--- a/core/src/main/groovy/noe/ews/server/httpd/HttpdRhel.groovy
+++ b/core/src/main/groovy/noe/ews/server/httpd/HttpdRhel.groovy
@@ -34,6 +34,7 @@ class HttpdRhel extends Httpd {
     configureApachectl()
     this.deploymentPath = this.basedir + "/www/html"
     this.confDeploymentPath = this.basedir + "/${DefaultProperties.CONF_DIRECTORY}"
+    this.confModulesDeploymentPath = this.basedir + "/${DefaultProperties.CONF_MODULES_DIRECTORY}"
     this.cgiDeploymentPath = this.basedir + "/www/cgi-bin"
     this.modClusterCacheDir = this.basedir + "/cache/mod_cluster"
     this.opensslPath = 'openssl' // openssl is in $PATH on RHEL by OS installation

--- a/core/src/main/groovy/noe/ews/server/httpd/HttpdRpm.groovy
+++ b/core/src/main/groovy/noe/ews/server/httpd/HttpdRpm.groovy
@@ -46,6 +46,7 @@ class HttpdRpm extends Httpd {
     this.apachectl = ['/usr/sbin/apachectl']
     this.deploymentPath = "/var/www/html"
     this.confDeploymentPath = this.basedir + "/${DefaultProperties.CONF_DIRECTORY}"
+    this.confModulesDeploymentPath = this.basedir + "/${DefaultProperties.CONF_MODULES_DIRECTORY}"
     this.cgiDeploymentPath = "/var/www/cgi-bin"
     this.cachePath = "/var/cache"
     this.modClusterCacheDir = cachePath + "/mod_cluster"

--- a/core/src/main/groovy/noe/ews/server/httpd/HttpdWindows.groovy
+++ b/core/src/main/groovy/noe/ews/server/httpd/HttpdWindows.groovy
@@ -44,6 +44,7 @@ class HttpdWindows extends Httpd {
     this.stop = apachectl + ["-k", "stop"]
     this.deploymentPath = this.basedir + "\\var\\www\\html"
     this.confDeploymentPath = this.basedir + httpdServerRoot + "\\${DefaultProperties.CONF_DIRECTORY}"
+    this.confModulesDeploymentPath = this.basedir + httpdServerRoot + "\\${DefaultProperties.CONF_MODULES_DIRECTORY}"
     this.cgiDeploymentPath = this.basedir + "\\var\\www\\cgi-bin"
     this.modClusterCacheDir = this.basedir + "\\var\\cache\\mod_cluster"
     this.opensslPath = this.binDir + "\\openssl.exe"

--- a/core/src/main/groovy/noe/jbcs/server/httpd/HttpdCoreRpm.groovy
+++ b/core/src/main/groovy/noe/jbcs/server/httpd/HttpdCoreRpm.groovy
@@ -35,6 +35,7 @@ class HttpdCoreRpm extends HttpdRpm {
     this.apachectl = [this.baseSCLdir + '/usr/sbin/apachectl']
     this.deploymentPath = this.baseSCLdir + "/var/www/html"
     this.confDeploymentPath = this.basedir + "/${DefaultProperties.CONF_DIRECTORY}"
+    this.confModulesDeploymentPath = this.basedir + "/${DefaultProperties.CONF_MODULES_DIRECTORY}"
     this.cgiDeploymentPath = this.baseSCLdir + "/var/www/cgi-bin"
     this.abPath = this.baseSCLdir + '/usr/bin/ab'
     this.htdbmPath = this.baseSCLdir + '/usr/bin/htdbm'

--- a/core/src/main/groovy/noe/jk/configure/DefaultTomcatWorkerConfigurator.groovy
+++ b/core/src/main/groovy/noe/jk/configure/DefaultTomcatWorkerConfigurator.groovy
@@ -47,7 +47,7 @@ class DefaultTomcatWorkerConfigurator implements Configurator<DefaultTomcatWorke
   DefaultTomcatWorkerConfigurator configure() {
     configurator
         .httpConnector(new NonSecureHttpConnectorTomcat().setAddress(workerNode.getHost()))
-        .ajpConnector(new AjpConnectorTomcat().setPort(workerNode.getAjpPort()))
+        .ajpConnector(new AjpConnectorTomcat().setPort(workerNode.getAjpPort()).setSecretRequired(false))
         .jvmRoute(workerNode.getId())
 
     return this

--- a/core/src/main/groovy/noe/rhel/server/httpd/HttpdBaseOS.groovy
+++ b/core/src/main/groovy/noe/rhel/server/httpd/HttpdBaseOS.groovy
@@ -49,6 +49,7 @@ class HttpdBaseOS extends Httpd {
     this.apachectl = ['/usr/sbin/apachectl']
     this.deploymentPath = "/var/www/html"
     this.confDeploymentPath = this.basedir + "/${DefaultProperties.CONF_DIRECTORY}"
+    this.confModulesDeploymentPath = this.basedir + "/${DefaultProperties.CONF_MODULES_DIRECTORY}"
     this.cgiDeploymentPath = "/var/www/cgi-bin"
     this.modClusterCacheDir = "/var/cache/mod_cluster"
     this.opensslPath = 'openssl' // openssl is on $PATH on RHEL by OS installation

--- a/core/src/main/groovy/noe/server/Httpd.groovy
+++ b/core/src/main/groovy/noe/server/Httpd.groovy
@@ -35,6 +35,7 @@ abstract class Httpd extends ServerAbstract {
   String httpdworker = "sudo ./httpd.worker"
   String cgiDeploymentPath   // CGI scripts deplyment path for httpd
   String modClusterCacheDir  // directory for storing cached data
+  int mainClusterManagementPort = 6666
   String opensslPath         // openssl PATH
   String abPath         // path for the ApacheBench
   String htdbmPath      // path Manipulate DBM password databases
@@ -309,6 +310,18 @@ abstract class Httpd extends ServerAbstract {
     serverName = 'ServerName ' + ((DefaultProperties.HTTPD_SERVER_NAME.contains(':') && !DefaultProperties.HTTPD_SERVER_NAME.contains(']')) ? '[' + DefaultProperties.HTTPD_SERVER_NAME + ']' : DefaultProperties.HTTPD_SERVER_NAME) + ':' + port
     updateConfReplaceRegExp('ssl.conf', 'ServerName (.*)', serverName, true)
     mainHttpsPort = port
+
+    // CLUSTER MANAGER
+    log.debug("mainClusterManagementPort:${mainClusterManagementPort}, offset:${offset}")
+    port = offset + mainClusterManagementPort
+    listen = 'Listen ' + ((host.contains(':') && !host.contains(']')) ? '[' + host + ']' : host) + ':' + port
+    log.debug('New Listen: ' + listen)
+    updateConfReplaceRegExp(DefaultProperties.MOD_CLUSTER_CONFIG_FILE, 'Listen (.*)', listen, true)
+    updateConfReplaceRegExp(DefaultProperties.MOD_PROXY_CLUSTER_CONFIG_FILE, 'Listen (.*)', listen, true)
+    updateConfReplaceRegExp(DefaultProperties.MOD_CLUSTER_CONFIG_FILE, '<VirtualHost \\*:(.*)', "<VirtualHost \\*:${port}>", true)
+    updateConfReplaceRegExp(DefaultProperties.MOD_PROXY_CLUSTER_CONFIG_FILE, '<VirtualHost \\*:(.*)', "<VirtualHost \\*:${port}>", true)
+    mainClusterManagementPort = port
+
   }
 
   void modJkSetSticky(value, boolean restart = true) {

--- a/core/src/main/groovy/noe/server/Httpd.groovy
+++ b/core/src/main/groovy/noe/server/Httpd.groovy
@@ -33,7 +33,8 @@ abstract class Httpd extends ServerAbstract {
   List<String> apachectl       // apachectl Script/Binary
   String httpdevent = "sudo ./httpd.event"
   String httpdworker = "sudo ./httpd.worker"
-  String cgiDeploymentPath   // CGI scripts deplyment path for httpd
+  String confModulesDeploymentPath   // modules configuration deployment path for httpd
+  String cgiDeploymentPath   // CGI scripts deployment path for httpd
   String modClusterCacheDir  // directory for storing cached data
   int mainClusterManagementPort = 6666
   String opensslPath         // openssl PATH
@@ -76,7 +77,7 @@ abstract class Httpd extends ServerAbstract {
   }
 
   static ServerAbstract getInstance(String basedir, version, String httpdDir = '', NoeContext context = NoeContext.forCurrentContext()) {
-    def server
+    ServerAbstract server
 
     if (context.areInSingleGroup(['ews', 'rpm']) || DefaultProperties.USE_HTTPD_RPM) {
       if (DefaultProperties.apacheCoreVersion()) {

--- a/core/src/test/groovy/noe/server/ServerAbstractTest.groovy
+++ b/core/src/test/groovy/noe/server/ServerAbstractTest.groovy
@@ -47,7 +47,7 @@ class ServerAbstractTest {
       JBFile.mkdir(new File(PathHelper.join(baseDir.getAbsolutePath(), logDir)))
     }
 
-    server = new TestServer(baseDir.getAbsolutePath(), '2.4.23')
+    server = new TestServer(baseDir.getAbsolutePath(), '2.4.51')
     server.setLogDirs(logDirs)
   }
 

--- a/testsuite/src/test/groovy/noe/HttpdKillTestIT.groovy
+++ b/testsuite/src/test/groovy/noe/HttpdKillTestIT.groovy
@@ -39,6 +39,10 @@ class HttpdKillTestIT extends TestAbstract {
       def mod_clusterConfFile = new File(httpdServer.getConfDeploymentPath(), DefaultProperties.MOD_CLUSTER_CONFIG_FILE)
       log.debug("Deleting ${DefaultProperties.MOD_CLUSTER_CONFIG_FILE}: $mod_clusterConfFile.absolutePath")
       JBFile.delete(mod_clusterConfFile)
+      // remove mod_proxy_cluster too
+      mod_clusterConfFile = new File(httpdServer.getConfDeploymentPath(), DefaultProperties.MOD_PROXY_CLUSTER_CONFIG_FILE)
+      log.debug("Deleting ${DefaultProperties.MOD_PROXY_CLUSTER_CONFIG_FILE}: $mod_clusterConfFile.absolutePath")
+      JBFile.delete(mod_clusterConfFile)
     }
   }
 

--- a/testsuite/src/test/groovy/noe/TomcatJws31IT.groovy
+++ b/testsuite/src/test/groovy/noe/TomcatJws31IT.groovy
@@ -17,7 +17,7 @@ class TomcatJws31IT extends TestAbstract {
   public static void beforeClass() {
     Platform platform = new Platform()
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
-    Assume.assumeFalse("JWS 3.1 is not supported on RHEL5 => skipping", platform.isRHEL5())
+    Assume.assumeTrue("JWS 3.1 is not supported on RHEL8+ => skipping", platform.isRHEL7())
     Assume.assumeTrue("Tomcat from JWS 3.1 requires at least Java 1.7", Java.isJdk1xOrHigher('1.7'))
     loadTestProperties('/jws31-test.properties')
     workspace = new ServersWorkspace(

--- a/testsuite/src/test/groovy/noe/TomcatJws4IT.groovy
+++ b/testsuite/src/test/groovy/noe/TomcatJws4IT.groovy
@@ -18,7 +18,7 @@ class TomcatJws4IT extends TestAbstract {
   public static void beforeClass() {
     Platform platform = new Platform()
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
-    Assume.assumeFalse("JWS 4 is not supported on RHEL5 => skipping", platform.isRHEL5())
+    Assume.assumeTrue("JWS 4 is not supported on RHEL8+ => skipping", platform.isRHEL7())
     Assume.assumeTrue("Tomcat from JWS 4 requires at least Java 1.8", Java.isJdk1xOrHigher('1.8'))
     Assume.assumeTrue("We have currently only builds for RHEL, skipping for other platforms",
             platform.isRHEL())

--- a/testsuite/src/test/groovy/noe/modjk/JkConfiguratorTestIT.groovy
+++ b/testsuite/src/test/groovy/noe/modjk/JkConfiguratorTestIT.groovy
@@ -61,7 +61,7 @@ class JkConfiguratorTestIT extends TestAbstract {
   static Collection<Object[]> data() {
     Platform platform = new Platform()
     boolean modJkPlatforms =
-            (platform.isRHEL7() && (platform.isX64())) ||
+            (platform.isRHEL() && (platform.isX64())) ||
             (platform.isSolaris11() && platform.isX64()) ||
             (platform.isWindows() && platform.isX64())
 

--- a/testsuite/src/test/groovy/noe/modjk/JkConfiguratorTestIT.groovy
+++ b/testsuite/src/test/groovy/noe/modjk/JkConfiguratorTestIT.groovy
@@ -61,7 +61,7 @@ class JkConfiguratorTestIT extends TestAbstract {
   static Collection<Object[]> data() {
     Platform platform = new Platform()
     boolean modJkPlatforms =
-            (platform.isRHEL() && (platform.isX64())) ||
+            (platform.isRHEL7() && (platform.isX64())) ||
             (platform.isSolaris11() && platform.isX64()) ||
             (platform.isWindows() && platform.isX64())
 

--- a/testsuite/src/test/groovy/noe/modjk/JkConfiguratorTestIT.groovy
+++ b/testsuite/src/test/groovy/noe/modjk/JkConfiguratorTestIT.groovy
@@ -530,7 +530,11 @@ class JkConfiguratorTestIT extends TestAbstract {
     }
 
     String retrievePropertiesFileName() {
-      if (workerServerClass == Tomcat.class) return "ews-test.properties"
+      if (workerServerClass == Tomcat.class) {
+        Platform platform = new Platform()
+        if (platform.isRHEL7()) return "ews-rhel7-test.properties"
+        else return "ews-test.properties"
+      }
       else return "eap6-test.properties"
     }
 

--- a/testsuite/src/test/groovy/noe/modjk/JkConfiguratorTestIT.groovy
+++ b/testsuite/src/test/groovy/noe/modjk/JkConfiguratorTestIT.groovy
@@ -526,6 +526,11 @@ class JkConfiguratorTestIT extends TestAbstract {
         def sslConfFile = new File(facingServer.getConfDeploymentPath(), "ssl.conf")
         log.debug("Deleting ssl.conf: $sslConfFile.absolutePath")
         JBFile.delete(sslConfFile)
+        // we are not testing cgid here, lets remove cgi.conf (requires cgid with worker/event)
+        def cgiConfFile = new File(facingServer.getConfModulesDeploymentPath(), "01-cgi.conf")
+        log.debug("Deleting cgi.conf: $cgiConfFile.absolutePath")
+        JBFile.delete(cgiConfFile)
+
       }
     }
 

--- a/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat7ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat7ConfiguratorIT.groovy
@@ -1,5 +1,7 @@
 package noe.tomcat
 
+import noe.common.utils.Platform
+import org.junit.Assume
 import org.junit.BeforeClass
 
 
@@ -7,6 +9,7 @@ class BindingsTomcat7ConfiguratorIT extends BindingsTomcatConfiguratorIT {
 
   @BeforeClass
   public static void beforeClass() {
+    Assume.assumeTrue("Tomcat 7 is not released for RHEL8+", new Platform().isRHEL7())
     loadTestProperties("/tomcat7-common-test.properties")
     prepareWorkspace()
   }

--- a/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat8ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat8ConfiguratorIT.groovy
@@ -11,7 +11,7 @@ class BindingsTomcat8ConfiguratorIT extends BindingsTomcatConfiguratorIT {
   public static void beforeClass() {
     Platform platform = new Platform()
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
-    Assume.assumeFalse("JWS 3.0 is not supported on RHEL5 => skipping", platform.isRHEL5())
+    Assume.assumeTrue("JWS 3.0 is not supported on RHEL8+ => skipping", platform.isRHEL6() || platform.isRHEL7())
     Assume.assumeTrue("Tomcat from JWS 3.0 requires at least Java 1.7", Java.isJdk1xOrHigher('1.7'))
 
     loadTestProperties("/tomcat8-common-test.properties")

--- a/testsuite/src/test/groovy/noe/tomcat/BindingsTomcatConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/BindingsTomcatConfiguratorIT.groovy
@@ -180,8 +180,8 @@ abstract class BindingsTomcatConfiguratorIT extends TomcatTestAbstract {
     GPathResult Server = new XmlSlurper().parse(new File(tomcat.basedir, "conf/server.xml"))
     assertEquals onlyOneAjpConnector, Server.Service.Connector.find { isAjpProtocol(it) && !isSecure(it)  }.size()
     assertEquals testAjpPort, Integer.valueOf(Server.Service.Connector.find { isAjpProtocol(it) }.@port.toString())
-    assertEquals Tomcat.DEFAULT_HTTPS_PORT, Integer.valueOf(Server.Service.Connector.find { isAjpProtocol(it) }.@redirectPort.toString())
-    assertEquals defAttributesCountOfAjpConnector, Server.Service.Connector.find { isAjpProtocol(it) }.attributes().size()
+    if(tomcat.getVersion().majorVersion<9) assertEquals Tomcat.DEFAULT_HTTPS_PORT, Integer.valueOf(Server.Service.Connector.find { isAjpProtocol(it) }.@redirectPort.toString())
+    if(tomcat.getVersion().majorVersion<9) assertEquals defAttributesCountOfAjpConnector, Server.Service.Connector.find { isAjpProtocol(it) }.attributes().size()
   }
 
   @Test
@@ -264,7 +264,7 @@ abstract class BindingsTomcatConfiguratorIT extends TomcatTestAbstract {
     assertEquals Tomcat.DEFAULT_HTTPS_PORT, Integer.valueOf(Server.Service.Connector.find { isNotSecuredHttpProtocol(it) }.@redirectPort.toString())
     assertEquals "", Server.Service.Connector.find { isSecure(it) }.@port.toString() // https connector was not created by port shifting
     assertEquals shiftedShutdownPort, Integer.valueOf(Server.@port.toString())
-    assertEquals shiftedAjpPort, Integer.valueOf(Server.Service.Connector.find { isAjpProtocol(it) }.@port.toString())
+    if(tomcat.getVersion().majorVersion<9) assertEquals shiftedAjpPort, Integer.valueOf(Server.Service.Connector.find { isAjpProtocol(it) }.@port.toString())
   }
 
   @Test

--- a/testsuite/src/test/groovy/noe/tomcat/JmxTomcat7ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JmxTomcat7ConfiguratorIT.groovy
@@ -1,12 +1,15 @@
 package noe.tomcat
 
+import org.junit.Assume
 import org.junit.BeforeClass
+import noe.common.utils.Platform
 
 
 class JmxTomcat7ConfiguratorIT extends JmxTomcatConfiguratorIT {
 
   @BeforeClass
   public static void beforeClass() {
+    Assume.assumeTrue("Tomcat 7 is not released for RHEL8+", new Platform().isRHEL7())
     loadTestProperties("/tomcat7-common-test.properties")
     prepareWorkspace()
   }

--- a/testsuite/src/test/groovy/noe/tomcat/JmxTomcat8ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JmxTomcat8ConfiguratorIT.groovy
@@ -11,7 +11,7 @@ class JmxTomcat8ConfiguratorIT extends JmxTomcatConfiguratorIT {
   public static void beforeClass() {
     Platform platform = new Platform()
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
-    Assume.assumeFalse("JWS 3.0 is not supported on RHEL5 => skipping", platform.isRHEL5())
+    Assume.assumeTrue("JWS 3.0 is not supported from RHEL8+ => skipping", platform.isRHEL7())
     Assume.assumeTrue("Tomcat from JWS 3.0 requires at least Java 1.7", Java.isJdk1xOrHigher('1.7'))
 
     loadTestProperties("/tomcat8-common-test.properties")

--- a/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat7ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat7ConfiguratorIT.groovy
@@ -1,5 +1,7 @@
 package noe.tomcat
 
+import noe.common.utils.Platform
+import org.junit.Assume
 import org.junit.BeforeClass
 
 
@@ -7,6 +9,7 @@ class JvmRouteTomcat7ConfiguratorIT extends JvmRouteTomcatConfiguratorIT {
 
   @BeforeClass
   public static void beforeClass() {
+    Assume.assumeTrue("Tomcat 7 is not released for RHEL8+", new Platform().isRHEL7())
     loadTestProperties("/tomcat7-common-test.properties")
     prepareWorkspace()
   }

--- a/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat8ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat8ConfiguratorIT.groovy
@@ -11,7 +11,7 @@ class JvmRouteTomcat8ConfiguratorIT extends JvmRouteTomcatConfiguratorIT {
   public static void beforeClass() {
     Platform platform = new Platform()
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
-    Assume.assumeFalse("JWS 3.0 is not supported on RHEL5 => skipping", platform.isRHEL5())
+    Assume.assumeTrue("JWS 3.0 is not supported on RHEL8+ => skipping", platform.isRHEL6() || platform.isRHEL7())
     Assume.assumeTrue("Tomcat from JWS 3.0 requires at least Java 1.7", Java.isJdk1xOrHigher('1.7'))
 
     loadTestProperties("/tomcat8-common-test.properties")

--- a/testsuite/src/test/groovy/noe/tomcat/configure/envars/ConfsBckpRestoreTomcat7ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/configure/envars/ConfsBckpRestoreTomcat7ConfiguratorIT.groovy
@@ -1,12 +1,14 @@
 package noe.tomcat.configure.envars
 
+import org.junit.Assume
 import org.junit.BeforeClass
-
+import noe.common.utils.Platform
 
 class ConfsBckpRestoreTomcat7ConfiguratorIT extends ConfsBckpRestoreTomcatConfiguratorIT {
 
   @BeforeClass
    static void beforeClass() {
+    Assume.assumeTrue("EWS 3.1.0 is not supported on RHEL8+", new Platform().isRHEL7())
     loadTestProperties("/tomcat7-common-test.properties")
     prepareWorkspace()
   }

--- a/testsuite/src/test/groovy/noe/tomcat/configure/envars/ConfsBckpRestoreTomcat8ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/configure/envars/ConfsBckpRestoreTomcat8ConfiguratorIT.groovy
@@ -1,12 +1,14 @@
 package noe.tomcat.configure.envars
 
+import org.junit.Assume
 import org.junit.BeforeClass
-
+import noe.common.utils.Platform
 
 class ConfsBckpRestoreTomcat8ConfiguratorIT extends ConfsBckpRestoreTomcatConfiguratorIT {
 
   @BeforeClass
    static void beforeClass() {
+    Assume.assumeTrue("EWS 3.1.0 is not supported on RHEL8+", new Platform().isRHEL7())
     loadTestProperties("/tomcat8-common-test.properties")
     prepareWorkspace()
   }

--- a/testsuite/src/test/resources/core-test.properties
+++ b/testsuite/src/test/resources/core-test.properties
@@ -1,2 +1,2 @@
-apache.core.version=2.4.23
-ews.version=3.1.0
+apache.core.version=2.4.51
+ews.version=5.7.0

--- a/testsuite/src/test/resources/eap7-jbcs-test.properties
+++ b/testsuite/src/test/resources/eap7-jbcs-test.properties
@@ -1,3 +1,3 @@
 eap.version=7.1.0
-apache.core.version=2.4.23
+apache.core.version=2.4.51
 context=eap6

--- a/testsuite/src/test/resources/eap7-multiple-jbcs-httpd-test.properties
+++ b/testsuite/src/test/resources/eap7-multiple-jbcs-httpd-test.properties
@@ -1,4 +1,4 @@
 eap.version=7.0.0
-ews.version=3.1.0
+ews.version=5.7.0
 context=eap6
-apache.core.version=2.4.23
+apache.core.version=2.4.51

--- a/testsuite/src/test/resources/ews-rhel7-test.properties
+++ b/testsuite/src/test/resources/ews-rhel7-test.properties
@@ -1,5 +1,5 @@
 ews.version=3.1.0
 context=ews
 JBPAPP9445_WORKAROUND=true
-apache.core.version=2.4.37-SP7
+apache.core.version=2.4.51
 tomcat.major.version=8

--- a/testsuite/src/test/resources/ews-rhel7-test.properties
+++ b/testsuite/src/test/resources/ews-rhel7-test.properties
@@ -1,0 +1,5 @@
+ews.version=3.1.0
+context=ews
+JBPAPP9445_WORKAROUND=true
+apache.core.version=2.4.37-SP7
+tomcat.major.version=8

--- a/testsuite/src/test/resources/ews-test.properties
+++ b/testsuite/src/test/resources/ews-test.properties
@@ -1,6 +1,5 @@
-ews.version=3.1.0
+ews.version=5.7.0
 context=ews
 JBPAPP9445_WORKAROUND=true
-apache.core.version=2.4.23
-tomcat.major.version=8
-
+apache.core.version=2.4.51
+tomcat.major.version=9

--- a/testsuite/src/test/resources/jws5-test.properties
+++ b/testsuite/src/test/resources/jws5-test.properties
@@ -1,4 +1,4 @@
-ews.version=5.0.0
+ews.version=5.7.0
 context=ews
-apache.core.version=2.4.29
+apache.core.version=2.4.51
 tomcat.major.version=9

--- a/testsuite/src/test/resources/tomcat9-common-test.properties
+++ b/testsuite/src/test/resources/tomcat9-common-test.properties
@@ -1,4 +1,4 @@
-ews.version=5.0.0
+ews.version=5.7.0
 context=ews
 JBPAPP9445_WORKAROUND=true
 tomcat.major.version=9


### PR DESCRIPTION
This pull request makes most integration tests run for RHEL8, while keeping all RHEL7 tests running.
