### PR TITLE
Use default value if PidFile is not set up in the configuration

### DIFF
--- a/core/src/main/groovy/noe/common/utils/Cmd.groovy
+++ b/core/src/main/groovy/noe/common/utils/Cmd.groovy
@@ -799,10 +799,10 @@ public class Cmd {
     Pattern psRegExp
     if (platform.isHP()) {
       psCommand = ['ps', '-elfx']
-      psRegExp = ~/^[0-9]*[ ]*[A-Z][ ]*[a-z]*[ ]*([0-9]*).*/
+      psRegExp = ~/^[0-9]*[ ]*[A-Z][ ]*[a-z]*[ ]*([0-9]+).*/
     } else {
       psCommand = ['ps', '-ef']
-      psRegExp = ~/^[ a-z]*[ ]*([0-9]*)[ ]*[0-9]*.*/
+      psRegExp = ~/^[ a-z+]*[ ]*([0-9]+)[ ]*[0-9]*.*/
     }
 
     /**
@@ -855,7 +855,8 @@ public class Cmd {
           javaPids.add(Long.parseLong(pid))
         } catch (NumberFormatException ex) {
           log.error("Error trying to parse process ID from: \"${pid}\"")
-          throw ex
+          //ignore non-pid matches, consider the rest
+          //throw ex
         }
       }
 
@@ -899,7 +900,8 @@ public class Cmd {
         pids.add(Long.parseLong(pid))
       } catch (NumberFormatException ex) {
         log.error("Error trying to parse process ID from: \"${pid}\"")
-        throw ex
+        //ignore non-pid match
+        //throw ex
       }
     }
 

--- a/core/src/main/groovy/noe/server/Httpd.groovy
+++ b/core/src/main/groovy/noe/server/Httpd.groovy
@@ -357,32 +357,38 @@ abstract class Httpd extends ServerAbstract {
    */
   File getPidFile() {
     File httpdConfFile = null
-    configDirs.each { configDir ->
-      def confToCheckFile = new File("${basedir}${platform.sep}${configDir}${platform.sep}httpd.conf")
-      if (confToCheckFile.exists()) {
-        httpdConfFile = confToCheckFile
-      }
-    }
     def pidPattern = "^PidFile\\s+(.*)"
     Pattern pattern = Pattern.compile(pidPattern)
     String line
-    httpdConfFile?.withReader { reader ->
-      while ((line = reader.readLine()) != null) {
-        Matcher matcher = pattern.matcher(line)
-        if (matcher.matches()) {
-          String pidFilePath = matcher.group(1)
-          matcher = (pidFilePath =~ /(.*)\s+/) //Take care of any spaces after path
-          if (matcher.matches()) {
-            pidFilePath = matcher.group(1)
+    def results = configDirs.findResults { configDir ->
+      def confToCheckFile = new File("${basedir}${platform.sep}${configDir}${platform.sep}httpd.conf")
+      if (confToCheckFile.exists()) {
+        httpdConfFile = confToCheckFile
+        return httpdConfFile?.withReader { reader ->
+          while ((line = reader.readLine()) != null) {
+            Matcher matcher = pattern.matcher(line)
+            if (matcher.matches()) {
+              String pidFilePath = matcher.group(1)
+              matcher = (pidFilePath =~ /(.*)\s+/) //Take care of any spaces after path
+              if (matcher.matches()) {
+                pidFilePath = matcher.group(1)
+              }
+              matcher = (pidFilePath =~ /"(.*)"/)
+              if (matcher.matches()) {
+                pidFilePath = matcher.group(1)
+              }
+              def pidFile = new File(pidFilePath)
+              return (pidFile.isAbsolute() ? pidFile : new File(getHttpdServerRootFull(), pidFilePath))
+            }
           }
-          matcher = (pidFilePath =~ /"(.*)"/)
-          if (matcher.matches()) {
-            pidFilePath = matcher.group(1)
-          }
-          File pidFile = new File(pidFilePath)
-          return pidFile.isAbsolute() ? pidFile : new File(getHttpdServerRootFull(), pidFilePath)
         }
       }
+    }
+    if(results.isEmpty()) {
+      // Default if option is missing in configuration. RHEL7 and RHEL8 use '/logs/httpd.pid', RHEL9 '/run/httpd.pid'
+      return new File(getHttpdServerRootFull(), platform.isRHEL9() ? '/run/httpd.pid' : '/logs/httpd.pid')
+    } else {
+      return results.first()
     }
   }
 

--- a/core/src/main/groovy/noe/server/Httpd.groovy
+++ b/core/src/main/groovy/noe/server/Httpd.groovy
@@ -319,8 +319,8 @@ abstract class Httpd extends ServerAbstract {
     log.debug('New Listen: ' + listen)
     updateConfReplaceRegExp(DefaultProperties.MOD_CLUSTER_CONFIG_FILE, 'Listen (.*)', listen, true)
     updateConfReplaceRegExp(DefaultProperties.MOD_PROXY_CLUSTER_CONFIG_FILE, 'Listen (.*)', listen, true)
-    updateConfReplaceRegExp(DefaultProperties.MOD_CLUSTER_CONFIG_FILE, '<VirtualHost \\*:(.*)', "<VirtualHost \\*:${port}>", true)
-    updateConfReplaceRegExp(DefaultProperties.MOD_PROXY_CLUSTER_CONFIG_FILE, '<VirtualHost \\*:(.*)', "<VirtualHost \\*:${port}>", true)
+    updateConfReplaceRegExp(DefaultProperties.MOD_CLUSTER_CONFIG_FILE, /<VirtualHost [*]:(.*)>/, /<VirtualHost *:${port}>/, true)
+    updateConfReplaceRegExp(DefaultProperties.MOD_PROXY_CLUSTER_CONFIG_FILE, /<VirtualHost [*]:(.*)>/, /<VirtualHost *:${port}>/, true)
     mainClusterManagementPort = port
 
   }

--- a/core/src/main/groovy/noe/server/ServerAbstract.groovy
+++ b/core/src/main/groovy/noe/server/ServerAbstract.groovy
@@ -599,7 +599,7 @@ abstract class ServerAbstract implements IApp {
 
       fileText = JBFile.read(file)
 
-      if (fileText.contains(replace)) {
+      if ( (useSimpleReplace && fileText.contains(replace)) || fileText.find(replace)) {
         log.trace('AFTER UPDATE:')
         log.trace('-----------------------------------------------')
         // show only text after change


### PR DESCRIPTION
In some of our tests the PidFile directive was missing from httpd configuration. If this happens noe-core errors out with NullPointerException. Use instead the default value.