### PR TITLE
Enable easy differenciation between Windows versions

### DIFF
--- a/core/src/main/groovy/noe/common/utils/Platform.groovy
+++ b/core/src/main/groovy/noe/common/utils/Platform.groovy
@@ -152,6 +152,18 @@ class Platform {
     return isHP() && (osName ==~ /.*11.*/)
   }
 
+  boolean isWindows2016() {
+    return isWindows() && osName.contains("Server 2016")
+  }
+
+  boolean isWindows2019() {
+    return isWindows() && osName.contains("Server 2019")
+  }
+
+  boolean isWindows2022() {
+    return isWindows() && osName.contains("Server 2022")
+  }
+
   boolean isFips() {
     if(isRHEL()) {
       // Using return (['/usr/bin/fips-mode-setup', '--is-enabled'].execute().waitFor() == 0)


### PR DESCRIPTION
Nothing big. For symmetry with RHEL and Solaris, methods to check for Windows versions. 2016, 2019 and 2022 (untested but maybe convenient in the future).