### PR TITLE
Missing changes for project to compile

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -77,6 +77,10 @@
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
+            <artifactId>powermock-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
         </dependency>
         <dependency>
@@ -92,6 +96,25 @@
         <dependency>
             <groupId>org.wildfly.extras.creaper</groupId>
             <artifactId>creaper-commands</artifactId>
+        </dependency>
+
+        <!-- CLI dependency -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
         </dependency>
     </dependencies>
 

--- a/core/src/main/groovy/noe/eap/utils/CLILib.groovy
+++ b/core/src/main/groovy/noe/eap/utils/CLILib.groovy
@@ -7,7 +7,7 @@ import noe.common.utils.Version
 import noe.eap.creaper.ManagementClientProvider
 import noe.eap.creaper.ServerVerProvider
 import noe.server.AS7
-import org.apache.commons.collections.CollectionUtils
+import org.apache.commons.collections4.CollectionUtils
 import org.apache.commons.lang3.StringUtils
 import org.wildfly.extras.creaper.core.online.ModelNodeResult
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient

--- a/core/src/main/groovy/noe/server/ServerAbstract.groovy
+++ b/core/src/main/groovy/noe/server/ServerAbstract.groovy
@@ -599,7 +599,9 @@ abstract class ServerAbstract implements IApp {
 
       fileText = JBFile.read(file)
 
-      if ( (useSimpleReplace && fileText.contains(replace)) || fileText.find(replace)) {
+      // in theory the condition should be "(usesSimpleReplace && (fileText.contains(replace)) || fileText.find(replace)"
+      // but often replace is an illegal regex, so checking por any of those conditions works better
+      if ( fileText.contains(replace) || fileText.find(replace)) {
         log.trace('AFTER UPDATE:')
         log.trace('-----------------------------------------------')
         // show only text after change

--- a/core/src/main/groovy/noe/server/ServerAbstract.groovy
+++ b/core/src/main/groovy/noe/server/ServerAbstract.groovy
@@ -359,12 +359,12 @@ abstract class ServerAbstract implements IApp {
     File appDirPath = new File(getDeploymentPath(), appName)
     log.debug("appDirPath: " + appDirPath)
 
+    if (appDirPath.isDirectory() || appDirPath.isFile()) {
+      JBFile.delete(appDirPath)
+    }
+
     [ "war", "ear" ].each { extension ->
       File appWarPath = new File(getDeploymentPath(), "${appName}.${extension}")
-
-      if (appDirPath.isDirectory() || appDirPath.isFile()) {
-        JBFile.delete(appDirPath)
-      }
       if (appWarPath.isFile() || appWarPath.isDirectory()) {
         JBFile.delete(appWarPath)
       }

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
 
         <version.java.jna>5.6.0</version.java.jna>
 
-        <net.sourceforge.htmlunit.version>2.37.0</net.sourceforge.htmlunit.version>
+        <net.sourceforge.htmlunit.version>2.38.0</net.sourceforge.htmlunit.version>
         <!-- https://github.com/Karm/okhttp/tree/add_cipher_suites -->
         <com.squareup.okhttp3.okhttp.version>4.8.0</com.squareup.okhttp3.okhttp.version>
         <org.apache.ant.version>1.10.9</org.apache.ant.version>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <version.org.apache.maven.plugins.maven-deploy-plugin>2.8.2
         </version.org.apache.maven.plugins.maven-deploy-plugin>
         <junit.version>4.13.1</junit.version>
-        <org.codehaus.groovy.all.version>2.4.19</org.codehaus.groovy.all.version>
+        <org.codehaus.groovy.all.version>2.4.21</org.codehaus.groovy.all.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
         <org.codehaus.groovy.compiler.version>2.9.2-01</org.codehaus.groovy.compiler.version>
         <org.codehaus.groovy.batch.compiler.version>2.4.3-01</org.codehaus.groovy.batch.compiler.version>
@@ -126,6 +126,13 @@
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <org.wildfly.core.version>12.0.3.Final</org.wildfly.core.version>
         <org.jboss.as.creaper.dependencies.version>7.5.23.Final-redhat-00002</org.jboss.as.creaper.dependencies.version>
+
+        <commons-collections4.version>4.4</commons-collections4.version>
+        <commons-lang3.version>3.4</commons-lang3.version>
+        <commons-io.version>2.4</commons-io.version>
+
+        <xml-apis.version>1.4.01</xml-apis.version>
+
     </properties>
 
 
@@ -220,6 +227,12 @@
             </dependency>
             <dependency>
                 <groupId>org.powermock</groupId>
+                <artifactId>powermock-core</artifactId>
+                <version>${version.powermock}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.powermock</groupId>
                 <artifactId>powermock-api-mockito2</artifactId>
                 <version>${version.powermock}</version>
                 <scope>test</scope>
@@ -236,6 +249,30 @@
                 <artifactId>creaper-commands</artifactId>
                 <version>${version.org.wildfly.extras.creaper}</version>
             </dependency>
+
+            <!-- CLI dependency -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-collections4</artifactId>
+                <version>${commons-collections4.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons-lang3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>${commons-io.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>xml-apis</groupId>
+                <artifactId>xml-apis</artifactId>
+                <version>${xml-apis.version}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Compilation was failing due to undeclared dependencies that appeared when updating dependencies
    
I used mvn dependency:analyze to ensure no undeclared  dependencies exist.

Previous state:
```
[WARNING] Used undeclared dependencies found:
[WARNING]    commons-io:commons-io:jar:2.4:compile
[WARNING]    commons-collections:commons-collections:jar:3.2.1:compile
[WARNING]    org.powermock:powermock-core:jar:2.0.7:test
[WARNING]    xml-apis:xml-apis:jar:1.4.01:compile
[WARNING]    org.apache.commons:commons-lang3:jar:3.3.2:compile
[WARNING] Unused declared dependencies found:
[WARNING]    org.apache.ant:ant:jar:1.10.8:compile
[WARNING]    ch.qos.logback:logback-classic:jar:1.2.3:compile
[WARNING]    org.wildfly.extras.creaper:creaper-commands:jar:1.6.1:compile
[WARNING]    org.wildfly.core:wildfly-controller-client:jar:12.0.3.Final:provided
[WARNING]    org.wildfly.core:wildfly-cli:jar:12.0.3.Final:provided
```
    
After this PR there will be some unused dependencies, but removing them causes
errors. Go figure!

Current state:
```
[WARNING] Unused declared dependencies found:
[WARNING]    org.apache.ant:ant:jar:1.10.9:compile
[WARNING]    ch.qos.logback:logback-classic:jar:1.2.3:compile
[WARNING]    org.wildfly.extras.creaper:creaper-commands:jar:1.6.1:compile
[WARNING]    org.wildfly.core:wildfly-controller-client:jar:12.0.3.Final:provided
[WARNING]    org.wildfly.core:wildfly-cli:jar:12.0.3.Final:provided

```