### PR TITLE
Fix TomcatProperties class for EAP scenarios

### DIFF
--- a/core/src/main/groovy/noe/ews/server/tomcat/TomcatProperties.groovy
+++ b/core/src/main/groovy/noe/ews/server/tomcat/TomcatProperties.groovy
@@ -29,7 +29,7 @@ class TomcatProperties {
       } else  if (ewsVersion?.getMajorVersion() == 6) {
         TOMCAT_MAJOR_VERSION = "10"
       } else {
-        throw new IllegalArgumentException("Unknown EWS version ${ewsVersion?.getMajorVersion()}")
+        TOMCAT_MAJOR_VERSION = null
       }
     } else {
       TOMCAT_MAJOR_VERSION = tomcatVersion.getMajorVersion().toString()


### PR DESCRIPTION
TomcatProperties class should not throw any Exception as it broke execution of tests in mixtured JWS & EAP scenario, see the confirmation [here](https://github.com/web-servers/noe-core/blob/master/core/src/main/groovy/noe/ews/server/tomcat/TomcatProperties.groovy#L14). Unfortunately that class is throwing Exception since latest release (0.17.14), which causes errors in (at least) EAP scenarios.

Last related changes was here: https://github.com/web-servers/noe-core/commit/ac8776444cfcf3b37b013cd5a1811f7d5590659f