### PR TITLE
Removed use of Creaper's offline management client

### DIFF
--- a/core/src/main/groovy/noe/eap/creaper/ManagementClientProvider.groovy
+++ b/core/src/main/groovy/noe/eap/creaper/ManagementClientProvider.groovy
@@ -3,7 +3,6 @@ package noe.eap.creaper
 import noe.common.utils.Library
 import noe.server.AS7
 import org.wildfly.extras.creaper.core.ManagementClient
-import org.wildfly.extras.creaper.core.ServerVersion
 import org.wildfly.extras.creaper.core.offline.OfflineManagementClient
 import org.wildfly.extras.creaper.core.offline.OfflineOptions
 import org.wildfly.extras.creaper.core.online.ManagementProtocol
@@ -21,13 +20,8 @@ final class ManagementClientProvider {
    * @return Initialized OnlineManagementClient, don't forget to close it
    */
   static OnlineManagementClient createOnlineManagementClient(AS7 serverInstance) {
-    int port = serverInstance.getManagementNativePort()
-    ManagementProtocol protocol = ManagementProtocol.REMOTE
-    if (ServerVerProvider.provideFor(serverInstance).greaterThan(ServerVersion.VERSION_1_8_0)) {
-      //EAP version > 6.4
-      port = serverInstance.getManagementHttpPort()
-      protocol = ManagementProtocol.HTTP_REMOTING
-    }
+    int port = serverInstance.getManagementHttpPort()
+    ManagementProtocol protocol =  ManagementProtocol.HTTP_REMOTING
 
     return ManagementClient.onlineLazy(OnlineOptions.standalone()
             .hostAndPort(Library.getUniversalProperty("eap.creaper.client.online.host", serverInstance.getHost()),
@@ -43,7 +37,9 @@ final class ManagementClientProvider {
    * Creates {@link OfflineManagementClient} for standalone instance
    * @param serverInstance target server instance which will be managed by this client
    * @return Initialized OfflineManagementClient
+   * @deprecated Issues with updated Creaper
    */
+  @Deprecated
   static OfflineManagementClient createOfflineManagementClient(AS7 serverInstance) {
 
     return ManagementClient.offline(OfflineOptions.standalone()

--- a/core/src/main/groovy/noe/eap/creaper/ServerVerProvider.groovy
+++ b/core/src/main/groovy/noe/eap/creaper/ServerVerProvider.groovy
@@ -17,21 +17,21 @@ import org.wildfly.extras.creaper.core.ServerVersion
 class ServerVerProvider {
 
   /**
-   * Get management API version of target server instance
-   * @param serverInstance AS7 instance
+   * Get management API version of target started server instance
+   * @param serverInstance Running AS7 instance
    * @return Management API version wrapped in {@link ServerVersion}
    */
   static ServerVersion provideFor(ServerAbstract serverInstance) {
     if (serverInstance instanceof AS7) {
-      return ManagementClientProvider.createOfflineManagementClient(serverInstance as AS7).version()
+      return ManagementClientProvider.createOnlineManagementClient(serverInstance as AS7).version()
     } else {
       throw new IllegalArgumentException("Server instance must be an EAP/Wildfly node!")
     }
   }
 
   /**
-   * Get management API version of target server instance
-   * @param id of server fow which the management API version will be provided
+   * Get management API version of target started server instance
+   * @param id of running server fow which the management API version will be provided
    * @return Management API version wrapped in {@link ServerVersion}
    */
   static ServerVersion provideFor(String serverID) {
@@ -40,8 +40,9 @@ class ServerVerProvider {
   }
 
   /**
-   * Get management API version from list of AS7 server IDs. It is expected, that all instances have same version.
-   * @param serverIds list of AS7 server ids
+   * Get management API version from list of running AS7 server IDs. It is expected, that all instances have same
+   * version.
+   * @param serverIds list of running AS7 server ids
    * @return Management API version wrapped in {@link ServerVersion}
    */
   static ServerVersion provideFor(Set<String> serverIds) {

--- a/core/src/main/groovy/noe/eap/utils/CLILib.groovy
+++ b/core/src/main/groovy/noe/eap/utils/CLILib.groovy
@@ -596,10 +596,6 @@ class CLILib {
       String escapedLocation =  CLILib.escapeQuotes(addVirtualHostBuilder.location)
       String locationCommand = "/subsystem=undertow/server=${addVirtualHostBuilder.server}" +
               "/host=${addVirtualHostBuilder.hostName}/location=${escapedLocation}:add(handler=welcome-content)"
-      if (ServerVerProvider.provideFor(addVirtualHostBuilder.as7serverInstance).lessThan(ServerVerProvider.getMngmtVerOfEAP("7.0.0.DR1"))) {
-        createCommand = "/subsystem=web/virtual-server=${addVirtualHostBuilder.hostName}:add"
-        return addVirtualHostBuilder.as7serverInstance.as7Cli.runArbitraryCommand(createCommand).exitValue
-      }
       addVirtualHostBuilder.as7serverInstance.as7Cli.runArbitraryCommand(createCommand).exitValue
       return addVirtualHostBuilder.as7serverInstance.as7Cli.runArbitraryCommand(locationCommand).exitValue
     }


### PR DESCRIPTION
Latest Creaper cannot be used with noe-core and current Creaper cannot be used with latest WildFly.