### PR TITLE
Update rhel httpd tomcat

### DIFF
--- a/core/src/main/groovy/noe/common/utils/Java.groovy
+++ b/core/src/main/groovy/noe/common/utils/Java.groovy
@@ -24,14 +24,14 @@ public class Java {
       if (!new File(serverJavaHome, "bin").exists()) {
         return
       }
-      String javac = PathHelper.join(serverJavaHome, "bin", "javac")
-      String java = PathHelper.join(serverJavaHome, "bin", "java")
+      String serverJavac = PathHelper.join(serverJavaHome, "bin", "javac")
+      String serverJava = PathHelper.join(serverJavaHome, "bin", "java")
       Library.copyResourceTo(javaHelperClassResource, new File("."))
-      Cmd.executeCommandConsumeStreams([javac, "JavaVersion.java"])
-      javaVersion = Cmd.executeCommandConsumeStreams([java, "JavaVersion", "-version"])["stdOut"].trim()
-      javaVendor = Cmd.executeCommandConsumeStreams([java, "JavaVersion", "-vendor"])["stdOut"].trim()
-      javaVmName = Cmd.executeCommandConsumeStreams([java, "JavaVersion", "-vmname"])["stdOut"].trim()
-      javaVmInfo = Cmd.executeCommandConsumeStreams([java, "JavaVersion", "-vminfo"])["stdOut"].trim()
+      Cmd.executeCommandConsumeStreams([serverJava, "JavaVersion.java"])
+      def serverJavaVersion = Cmd.executeCommandConsumeStreams([serverJava, "JavaVersion", "-version"])["stdOut"].trim()
+      def serverJavaVendor = Cmd.executeCommandConsumeStreams([serverJava, "JavaVersion", "-vendor"])["stdOut"].trim()
+      def serverJavaVmName = Cmd.executeCommandConsumeStreams([serverJava, "JavaVersion", "-vmname"])["stdOut"].trim()
+      def serverJavaVmInfo = Cmd.executeCommandConsumeStreams([serverJava, "JavaVersion", "-vminfo"])["stdOut"].trim()
       initialized = true
     }
   }

--- a/core/src/main/groovy/noe/common/utils/Platform.groovy
+++ b/core/src/main/groovy/noe/common/utils/Platform.groovy
@@ -54,7 +54,13 @@ class Platform {
   boolean OSVersionLessThan(int value) {
     if (isRHEL()) {
       int start = osVersion.indexOf("el") + "el".length()
-      return Integer.parseInt(osVersion.substring(start, osVersion.indexOf('_', start))) < value
+
+      // works for '_' (rhel8+) or '.' (rhel7)
+      def intermediate = osVersion.substring(start,
+              [osVersion.indexOf('_', start), osVersion.indexOf('.', start), osVersion.length()]
+                      .find { it > start })
+
+      return Integer.parseInt(intermediate) < value
     }
 
     if(isWindows()) {

--- a/core/src/main/groovy/noe/common/utils/Platform.groovy
+++ b/core/src/main/groovy/noe/common/utils/Platform.groovy
@@ -54,16 +54,11 @@ class Platform {
   boolean OSVersionLessThan(int value) {
     if (isRHEL()) {
       int start = osVersion.indexOf("el") + "el".length()
-
-      // works for '_' (rhel8+) or '.' (rhel7)
-      def intermediate = osVersion.substring(start,
-              [osVersion.indexOf('_', start), osVersion.indexOf('.', start), osVersion.length()]
-                      .find { it > start })
-
-      return Integer.parseInt(intermediate) < value
+      int end = osVersion.indexOf(isRHEL7() ? '.' : '_', start)
+      return Integer.parseInt(osVersion.substring(start, end)) < value
     }
 
-    if(isWindows()) {
+    if (isWindows()) {
       int start = osVersion.indexOf("Server") + "Server ".length()
       return Integer.parseInt(osVersion.substring(start)) < value
     }

--- a/core/src/main/groovy/noe/server/AS7.groovy
+++ b/core/src/main/groovy/noe/server/AS7.groovy
@@ -177,7 +177,7 @@ class AS7 extends ServerAbstract implements WorkerServer {
     cmdCommand.setEnvProperties(envVariables)
 
     final String javaHome = Library.getUniversalProperty("server.java.home","")
-    if (javaHome) {
+    if (javaHome && Java.isServerJdkLowerThan('9')) {
       process = startWithJavaHome(javaHome, cmdCommand)
     } else {
       log.debug("Starting with default JAVA_HOME.")

--- a/core/src/main/groovy/noe/tomcat/configure/JmxConfiguratorTomcat.groovy
+++ b/core/src/main/groovy/noe/tomcat/configure/JmxConfiguratorTomcat.groovy
@@ -1,7 +1,6 @@
 package noe.tomcat.configure
 
 import noe.common.utils.FileStateVault
-import noe.common.utils.Platform
 import noe.server.Tomcat
 import noe.tomcat.configure.envars.EnvVarsFile
 import noe.tomcat.configure.envars.EnvVarsFileFactory

--- a/core/src/main/groovy/noe/tomcat/configure/envars/RpmTomcatEnvVarsFileFactory.groovy
+++ b/core/src/main/groovy/noe/tomcat/configure/envars/RpmTomcatEnvVarsFileFactory.groovy
@@ -31,7 +31,9 @@ class RpmTomcatEnvVarsFileFactory {
       return new Jws3RpmTomcatEnvVarsFile(tomcatInstance, vault)
     } else if (run.isJws5TestsRunning()) {
       return new Jws5RpmTomcatEnvVarsFile(vault)
-    } else if (run.isBaseOsTomcatTestsRunning()) {
+    } else if (run.isJws6TestsRunning()) {
+      return new Jws6RpmTomcatEnvVarsFile(vault)
+    }  else if (run.isBaseOsTomcatTestsRunning()) {
       return new BaseOsRpmTomcatEnvVarsFile(vault, platform)
     } else {
       throw new IllegalArgumentException(
@@ -73,6 +75,22 @@ class RpmTomcatEnvVarsFileFactory {
     }
   }
 
+  private static class Jws6RpmTomcatEnvVarsFile extends RpmTomcatEnvVarsFileBase {
+    Jws6RpmTomcatEnvVarsFile() {
+      Platform platform = new Platform()
+      if (platform.isRHEL8() || platform.isRHEL9() || platform.isRHEL10()) {
+        this.envFile = new File('/etc/opt/rh/scls/jws5/sysconfig/tomcat')
+      } else {
+        this.envFile = new File('/etc/opt/rh/jws5/sysconfig/tomcat')
+      }
+    }
+
+    Jws6RpmTomcatEnvVarsFile(FileStateVault vault) {
+      this()
+      this.vault = vault
+    }
+  }
+
   private static class BaseOsRpmTomcatEnvVarsFile extends RpmTomcatEnvVarsFileBase {
 
     BaseOsRpmTomcatEnvVarsFile() {
@@ -103,6 +121,7 @@ class RpmTomcatEnvVarsFileFactory {
   protected static interface RpmRun {
     boolean isJws3TestsRunning()
     boolean isJws5TestsRunning()
+    boolean isJws6TestsRunning()
     boolean isBaseOsTomcatTestsRunning()
   }
 
@@ -116,6 +135,11 @@ class RpmTomcatEnvVarsFileFactory {
     @Override
     boolean isJws5TestsRunning(){
       return isCurrentJwsMajorVersion(5)
+    }
+
+    @Override
+    boolean isJws6TestsRunning(){
+      return isCurrentJwsMajorVersion(6)
     }
 
     @Override

--- a/core/src/main/groovy/noe/tomcat/configure/envars/RpmTomcatEnvVarsFileFactory.groovy
+++ b/core/src/main/groovy/noe/tomcat/configure/envars/RpmTomcatEnvVarsFileFactory.groovy
@@ -79,9 +79,9 @@ class RpmTomcatEnvVarsFileFactory {
     Jws6RpmTomcatEnvVarsFile() {
       Platform platform = new Platform()
       if (platform.isRHEL8() || platform.isRHEL9() || platform.isRHEL10()) {
-        this.envFile = new File('/etc/opt/rh/scls/jws5/sysconfig/tomcat')
+        this.envFile = new File('/etc/opt/rh/scls/jws6/sysconfig/tomcat')
       } else {
-        this.envFile = new File('/etc/opt/rh/jws5/sysconfig/tomcat')
+        this.envFile = new File('/etc/opt/rh/jws6/sysconfig/tomcat')
       }
     }
 

--- a/core/src/test/groovy/noe/server/ServerAbstractTest.groovy
+++ b/core/src/test/groovy/noe/server/ServerAbstractTest.groovy
@@ -47,7 +47,7 @@ class ServerAbstractTest {
       JBFile.mkdir(new File(PathHelper.join(baseDir.getAbsolutePath(), logDir)))
     }
 
-    server = new TestServer(baseDir.getAbsolutePath(), '2.4.51')
+    server = new TestServer(baseDir.getAbsolutePath(), '2.4.62')
     server.setLogDirs(logDirs)
   }
 

--- a/core/src/test/groovy/noe/tomcat/configure/envars/EnvVarsFileFactoryTest.groovy
+++ b/core/src/test/groovy/noe/tomcat/configure/envars/EnvVarsFileFactoryTest.groovy
@@ -38,6 +38,7 @@ class EnvVarsFileFactoryTest {
     EnvVarsFile envVars = RpmTomcatEnvVarsFileFactory.getInstance(tomcat, vault, [
       isJws3TestsRunning: { return true },
       isJws5TestsRunning: { return false },
+      isJws6TestsRunning: { return false },
       isBaseOsTomcatTestsRunning: { return false }
     ] as RpmTomcatEnvVarsFileFactory.RpmRun)
 
@@ -49,6 +50,7 @@ class EnvVarsFileFactoryTest {
     EnvVarsFile envVars = RpmTomcatEnvVarsFileFactory.getInstance(tomcat, vault, [
       isJws3TestsRunning: { return false },
       isJws5TestsRunning: { return true },
+      isJws6TestsRunning: { return false },
       isBaseOsTomcatTestsRunning: { return false }
     ] as RpmTomcatEnvVarsFileFactory.RpmRun)
 
@@ -62,10 +64,29 @@ class EnvVarsFileFactoryTest {
   }
 
   @Test
+  void getInstanceRpmJWS6() {
+    EnvVarsFile envVars = RpmTomcatEnvVarsFileFactory.getInstance(tomcat, vault, [
+            isJws3TestsRunning: { return false },
+            isJws5TestsRunning: { return false },
+            isJws6TestsRunning: { return true },
+            isBaseOsTomcatTestsRunning: { return false }
+    ] as RpmTomcatEnvVarsFileFactory.RpmRun)
+
+    String tomcatServicePath
+    if (platform.isRHEL8() || platform.isRHEL9() || platform.isRHEL10()) {
+      tomcatServicePath = "/etc/opt/rh/scls/jws6/sysconfig/tomcat"
+    } else {
+      tomcatServicePath = "/etc/opt/rh/jws6/sysconfig/tomcat"
+    }
+    Assume.assumeTrue envVars.getEnvFile().getPath() == tomcatServicePath
+  }
+
+  @Test
   void getInstanceRpmBaseOsRhel6() {
     EnvVarsFile envVars = RpmTomcatEnvVarsFileFactory.getInstance(tomcat, vault, [
       isJws3TestsRunning: { return false },
       isJws5TestsRunning: { return false },
+      isJws6TestsRunning: { return false },
       isBaseOsTomcatTestsRunning: { return true }
     ] as RpmTomcatEnvVarsFileFactory.RpmRun, [
       isRHEL6: { return true },
@@ -80,6 +101,7 @@ class EnvVarsFileFactoryTest {
     EnvVarsFile envVars = RpmTomcatEnvVarsFileFactory.getInstance(tomcat, vault, [
       isJws3TestsRunning: { return false },
       isJws5TestsRunning: { return false },
+      isJws6TestsRunning: { return false },
       isBaseOsTomcatTestsRunning: { return true }
     ] as RpmTomcatEnvVarsFileFactory.RpmRun, [
       isRHEL6: { return false },

--- a/pom.xml
+++ b/pom.xml
@@ -87,8 +87,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <version.java>1.6</version.java>
-        <version.min-maven>3.2.5</version.min-maven>
+        <version.java>1.8</version.java>
+        <version.min-maven>3.9.5</version.min-maven>
 
 
         <version.checkstyle-plugin>3.1.1</version.checkstyle-plugin>
@@ -104,7 +104,7 @@
 	<version.jgit>5.13.3.202401111512-r</version.jgit>
         <version.release-plugin>3.0.0-M1</version.release-plugin>
         <version.source-plugin>3.2.1</version.source-plugin>
-        <version.surefire-plugin>2.22.0</version.surefire-plugin>
+        <version.surefire-plugin>3.0.0-M9</version.surefire-plugin>
 
 
         <version.java.jna>5.6.0</version.java.jna>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <version.java>1.6</version.java>
+        <version.java>1.8</version.java>
         <version.min-maven>3.9.5</version.min-maven>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <version.java>1.8</version.java>
+        <version.java>1.6</version.java>
         <version.min-maven>3.9.5</version.min-maven>
 
 

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -54,11 +54,11 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>${version.failsafe-plugin}</version>
                 <configuration>
-                    <systemProperties>
+                    <systemPropertyVariables>
                         <logging.level>6</logging.level>
                         <project.root.path>.</project.root.path>
                         <host>127.0.0.1</host>
-                    </systemProperties>
+                    </systemPropertyVariables>
                     <reuseForks>false</reuseForks>
                     <trimStackTrace>false</trimStackTrace>
                     <runOrder>reversealphabetical</runOrder>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -54,11 +54,11 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>${version.failsafe-plugin}</version>
                 <configuration>
-                    <systemProperties>
-                        <logging.level>1</logging.level>
+                    <systemPropertyVariables>
+                        <logging.level>6</logging.level>
                         <project.root.path>.</project.root.path>
                         <host>127.0.0.1</host>
-                    </systemProperties>
+                    </systemPropertyVariables>
                     <reuseForks>false</reuseForks>
                     <trimStackTrace>false</trimStackTrace>
                     <runOrder>reversealphabetical</runOrder>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -54,11 +54,11 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>${version.failsafe-plugin}</version>
                 <configuration>
-                    <systemPropertyVariables>
-                        <logging.level>6</logging.level>
+                    <systemProperties>
+                        <logging.level>1</logging.level>
                         <project.root.path>.</project.root.path>
                         <host>127.0.0.1</host>
-                    </systemPropertyVariables>
+                    </systemProperties>
                     <reuseForks>false</reuseForks>
                     <trimStackTrace>false</trimStackTrace>
                     <runOrder>reversealphabetical</runOrder>

--- a/testsuite/src/test/groovy/noe/HttpdKillTestIT.groovy
+++ b/testsuite/src/test/groovy/noe/HttpdKillTestIT.groovy
@@ -23,6 +23,8 @@ class HttpdKillTestIT extends TestAbstract {
     Assume.assumeFalse('JBCS Httpd is not supported on HP-UX => skipping', platform.isHP())
     Assume.assumeFalse('JBCS Httpd is not supported on older versions of RHEL than RHEL 6',
             platform.isRHEL4() || platform.isRHEL5())
+    Assume.assumeTrue("EAP 7.0.0 is officially supported on RHEL versions earlier than 9", platform.OSVersionLessThan(9));
+
     loadTestProperties('/eap7-multiple-jbcs-httpd-test.properties')
     workspace = new ServersWorkspace(
             new WorkspaceMultipleHttpdAS7(false, false)

--- a/testsuite/src/test/groovy/noe/MultipleTomcatsIT.groovy
+++ b/testsuite/src/test/groovy/noe/MultipleTomcatsIT.groovy
@@ -19,7 +19,10 @@ class MultipleTomcatsIT extends TestAbstract {
 
     @BeforeClass
     static void beforeClass() {
+        Platform platform = new Platform()
+
         loadTestProperties('/ews-test.properties')
+        Assume.assumeFalse("JWS 6.0 is officially supported on RHEL versions 8 and above", platform.OSVersionLessThan(8));
         Assume.assumeFalse("EWS is not supported on HP-UX => skipping", new Platform().isHP())
         workspace = new ServersWorkspace(
                 new WorkspaceHttpdTomcats(1)

--- a/testsuite/src/test/groovy/noe/TomcatJws31IT.groovy
+++ b/testsuite/src/test/groovy/noe/TomcatJws31IT.groovy
@@ -20,7 +20,7 @@ class TomcatJws31IT extends TestAbstract {
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
     Assume.assumeTrue("JWS 3.1 is not supported on RHEL8+ => skipping", platform.isRHEL7())
     Assume.assumeTrue("Tomcat from JWS 3.1 requires at least Java 1.7",
-            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk1.7')) ?: Java.isJdk1xOrHigher('1.7')
+            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk1.7')) ?: Java.isJdkXOrHigher('1.7')
     )
 
     loadTestProperties('/jws31-test.properties')

--- a/testsuite/src/test/groovy/noe/TomcatJws31IT.groovy
+++ b/testsuite/src/test/groovy/noe/TomcatJws31IT.groovy
@@ -2,6 +2,7 @@ package noe
 
 import groovy.util.logging.Slf4j
 import noe.common.TestAbstract
+import noe.common.DefaultProperties
 import noe.common.utils.Java
 import noe.common.utils.Platform
 import noe.workspace.ServersWorkspace
@@ -18,7 +19,10 @@ class TomcatJws31IT extends TestAbstract {
     Platform platform = new Platform()
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
     Assume.assumeTrue("JWS 3.1 is not supported on RHEL8+ => skipping", platform.isRHEL7())
-    Assume.assumeTrue("Tomcat from JWS 3.1 requires at least Java 1.7", Java.isJdk1xOrHigher('1.7'))
+    Assume.assumeTrue("Tomcat from JWS 3.1 requires at least Java 1.7",
+            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk1.7')) ?: Java.isJdk1xOrHigher('1.7')
+    )
+
     loadTestProperties('/jws31-test.properties')
     workspace = new ServersWorkspace(
         new WorkspaceTomcat()

--- a/testsuite/src/test/groovy/noe/TomcatJws4IT.groovy
+++ b/testsuite/src/test/groovy/noe/TomcatJws4IT.groovy
@@ -21,7 +21,7 @@ class TomcatJws4IT extends TestAbstract {
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
     Assume.assumeTrue("JWS 4 is not supported on RHEL8+ => skipping", platform.isRHEL7())
     Assume.assumeTrue("Tomcat from JWS 4 requires at least Java 1.8",
-            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk1.8')) ?: Java.isJdk1xOrHigher('1.8')
+            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk1.8')) ?: Java.isJdkXOrHigher('1.8')
     )
 
     Assume.assumeTrue("We have currently only builds for RHEL, skipping for other platforms",

--- a/testsuite/src/test/groovy/noe/TomcatJws4IT.groovy
+++ b/testsuite/src/test/groovy/noe/TomcatJws4IT.groovy
@@ -2,6 +2,7 @@ package noe
 
 import groovy.util.logging.Slf4j
 import noe.common.TestAbstract
+import noe.common.DefaultProperties
 import noe.common.utils.Java
 import noe.common.utils.Platform
 import noe.workspace.ServersWorkspace
@@ -19,7 +20,10 @@ class TomcatJws4IT extends TestAbstract {
     Platform platform = new Platform()
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
     Assume.assumeTrue("JWS 4 is not supported on RHEL8+ => skipping", platform.isRHEL7())
-    Assume.assumeTrue("Tomcat from JWS 4 requires at least Java 1.8", Java.isJdk1xOrHigher('1.8'))
+    Assume.assumeTrue("Tomcat from JWS 4 requires at least Java 1.8",
+            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk1.8')) ?: Java.isJdk1xOrHigher('1.8')
+    )
+
     Assume.assumeTrue("We have currently only builds for RHEL, skipping for other platforms",
             platform.isRHEL())
     loadTestProperties('/jws4-test.properties')

--- a/testsuite/src/test/groovy/noe/TomcatJws5IT.groovy
+++ b/testsuite/src/test/groovy/noe/TomcatJws5IT.groovy
@@ -19,7 +19,7 @@ class TomcatJws5IT extends TestAbstract {
   public static void beforeClass() {
     Platform platform = new Platform()
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
-    Assume.assumeTrue("Tomcat from JWS 5 requires at least Java 1.8", Java.isJdk1xOrHigher('1.8'))
+    Assume.assumeTrue("Tomcat from JWS 5 requires at least Java 1.8", Java.isJdkXOrHigher('1.8'))
 
 
 

--- a/testsuite/src/test/groovy/noe/TomcatJws5IT.groovy
+++ b/testsuite/src/test/groovy/noe/TomcatJws5IT.groovy
@@ -2,6 +2,7 @@ package noe
 
 import groovy.util.logging.Slf4j
 import noe.common.TestAbstract
+import noe.common.DefaultProperties
 import noe.common.utils.Java
 import noe.common.utils.Platform
 import noe.workspace.ServersWorkspace
@@ -19,6 +20,9 @@ class TomcatJws5IT extends TestAbstract {
     Platform platform = new Platform()
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
     Assume.assumeTrue("Tomcat from JWS 5 requires at least Java 1.8", Java.isJdk1xOrHigher('1.8'))
+
+
+
     loadTestProperties('/jws5-test.properties')
     workspace = new ServersWorkspace(
             new WorkspaceTomcat()

--- a/testsuite/src/test/groovy/noe/TomcatJws6IT.groovy
+++ b/testsuite/src/test/groovy/noe/TomcatJws6IT.groovy
@@ -1,0 +1,50 @@
+package noe
+
+import groovy.util.logging.Slf4j
+import noe.common.TestAbstract
+import noe.common.utils.Java
+import noe.common.utils.Platform
+import noe.workspace.ServersWorkspace
+import noe.workspace.WorkspaceTomcat
+import org.junit.Assume
+import org.junit.BeforeClass
+import org.junit.Test
+
+@Slf4j
+class TomcatJws6IT extends TestAbstract {
+
+
+    @BeforeClass
+    public static void beforeClass() {
+        Platform platform = new Platform()
+        Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
+        Assume.assumeTrue("Tomcat from JWS 6 requires at least Java 11", Java.isJdk1xOrHigher('11'))
+        loadTestProperties('/jws6-test.properties')
+        workspace = new ServersWorkspace(
+                new WorkspaceTomcat()
+        )
+        workspace.prepare()
+    }
+
+    @Test
+    void serverStartStopTest() {
+        serverController.getServerIds().each { serverId ->
+            SingleServerTestUtils.serverStartStopTest(serverId)
+        }
+    }
+
+    @Test
+    void serverStartKillTest() {
+        serverController.getServerIds().each { serverId ->
+            SingleServerTestUtils.serverStartKillTest(serverId)
+        }
+    }
+
+    @Test
+    void killAllInSystemTest() {
+        serverController.getServerIds().each { serverId ->
+            SingleServerTestUtils.killAllInSystemTest(serverId)
+        }
+    }
+
+}

--- a/testsuite/src/test/groovy/noe/TomcatJws6IT.groovy
+++ b/testsuite/src/test/groovy/noe/TomcatJws6IT.groovy
@@ -2,6 +2,7 @@ package noe
 
 import groovy.util.logging.Slf4j
 import noe.common.TestAbstract
+import noe.common.DefaultProperties
 import noe.common.utils.Java
 import noe.common.utils.Platform
 import noe.workspace.ServersWorkspace
@@ -18,7 +19,10 @@ class TomcatJws6IT extends TestAbstract {
     public static void beforeClass() {
         Platform platform = new Platform()
         Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
-        Assume.assumeTrue("Tomcat from JWS 6 requires at least Java 11", Java.isJdk1xOrHigher('11'))
+        Assume.assumeTrue("Tomcat from JWS 6.0 requires at least Java 11",
+                (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk11')) ?: Java.isJdk1xOrHigher('11')
+        )
+
         loadTestProperties('/jws6-test.properties')
         workspace = new ServersWorkspace(
                 new WorkspaceTomcat()

--- a/testsuite/src/test/groovy/noe/TomcatJws6IT.groovy
+++ b/testsuite/src/test/groovy/noe/TomcatJws6IT.groovy
@@ -16,11 +16,11 @@ class TomcatJws6IT extends TestAbstract {
 
 
     @BeforeClass
-    public static void beforeClass() {
+    static void beforeClass() {
         Platform platform = new Platform()
         Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
         Assume.assumeTrue("Tomcat from JWS 6.0 requires at least Java 11",
-                (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk11')) ?: Java.isJdk1xOrHigher('11')
+                (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk11')) ?: Java.isJdkXOrHigher('11')
         )
 
         loadTestProperties('/jws6-test.properties')

--- a/testsuite/src/test/groovy/noe/TomcatJws6IT.groovy
+++ b/testsuite/src/test/groovy/noe/TomcatJws6IT.groovy
@@ -18,9 +18,13 @@ class TomcatJws6IT extends TestAbstract {
     @BeforeClass
     static void beforeClass() {
         Platform platform = new Platform()
+
+        def java11Indicators = ['jdk11', 'java-11', 'openjdk-11']
+        def serverJavaHomeMatches = java11Indicators.any { DefaultProperties.SERVER_JAVA_HOME?.contains(it) }
+
         Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
         Assume.assumeTrue("Tomcat from JWS 6.0 requires at least Java 11",
-                (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk11')) ?: Java.isJdkXOrHigher('11')
+                serverJavaHomeMatches ?: Java.isJdkXOrHigher('11')
         )
 
         loadTestProperties('/jws6-test.properties')

--- a/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat10ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat10ConfiguratorIT.groovy
@@ -13,7 +13,7 @@ class BindingsTomcat10ConfiguratorIT extends BindingsTomcatConfiguratorIT {
     Platform platform = new Platform()
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
     Assume.assumeTrue("Tomcat from JWS 6.0 requires at least Java 11",
-            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk11')) ?: Java.isJdk1xOrHigher('11')
+            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk11')) ?: Java.isJdkXOrHigher('11')
     )
 
     loadTestProperties("/tomcat10-common-test.properties")

--- a/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat10ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat10ConfiguratorIT.groovy
@@ -11,9 +11,12 @@ class BindingsTomcat10ConfiguratorIT extends BindingsTomcatConfiguratorIT {
   @BeforeClass
   public static void beforeClass() {
     Platform platform = new Platform()
+    def java11Indicators = ['jdk11', 'java-11', 'openjdk-11']
+    def serverJavaHomeMatches = java11Indicators.any { DefaultProperties.SERVER_JAVA_HOME?.contains(it) }
+
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
     Assume.assumeTrue("Tomcat from JWS 6.0 requires at least Java 11",
-            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk11')) ?: Java.isJdkXOrHigher('11')
+            serverJavaHomeMatches ?: Java.isJdkXOrHigher('11')
     )
 
     loadTestProperties("/tomcat10-common-test.properties")

--- a/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat10ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat10ConfiguratorIT.groovy
@@ -1,0 +1,19 @@
+package noe.tomcat
+
+import noe.common.utils.Java
+import noe.common.utils.Platform
+import org.junit.Assume
+import org.junit.BeforeClass
+
+class BindingsTomcat10ConfiguratorIT extends BindingsTomcatConfiguratorIT {
+
+  @BeforeClass
+  public static void beforeClass() {
+    Platform platform = new Platform()
+    Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
+    Assume.assumeTrue("Tomcat from JWS 6.0 requires at least Java 11", Java.isJdk1xOrHigher('11'))
+
+    loadTestProperties("/tomcat10-common-test.properties")
+    prepareWorkspace()
+  }
+}

--- a/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat10ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat10ConfiguratorIT.groovy
@@ -1,5 +1,6 @@
 package noe.tomcat
 
+import noe.common.DefaultProperties
 import noe.common.utils.Java
 import noe.common.utils.Platform
 import org.junit.Assume
@@ -11,7 +12,9 @@ class BindingsTomcat10ConfiguratorIT extends BindingsTomcatConfiguratorIT {
   public static void beforeClass() {
     Platform platform = new Platform()
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
-    Assume.assumeTrue("Tomcat from JWS 6.0 requires at least Java 11", Java.isJdk1xOrHigher('11'))
+    Assume.assumeTrue("Tomcat from JWS 6.0 requires at least Java 11",
+            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk11')) ?: Java.isJdk1xOrHigher('11')
+    )
 
     loadTestProperties("/tomcat10-common-test.properties")
     prepareWorkspace()

--- a/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat10ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat10ConfiguratorIT.groovy
@@ -15,6 +15,7 @@ class BindingsTomcat10ConfiguratorIT extends BindingsTomcatConfiguratorIT {
     def serverJavaHomeMatches = java11Indicators.any { DefaultProperties.SERVER_JAVA_HOME?.contains(it) }
 
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
+    Assume.assumeFalse("JWS 6.0 is officially supported on RHEL versions 8 and above", platform.OSVersionLessThan(8));
     Assume.assumeTrue("Tomcat from JWS 6.0 requires at least Java 11",
             serverJavaHomeMatches ?: Java.isJdkXOrHigher('11')
     )

--- a/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat8ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat8ConfiguratorIT.groovy
@@ -1,5 +1,6 @@
 package noe.tomcat
 
+import noe.common.DefaultProperties
 import noe.common.utils.Java
 import noe.common.utils.Platform
 import org.junit.Assume
@@ -12,7 +13,10 @@ class BindingsTomcat8ConfiguratorIT extends BindingsTomcatConfiguratorIT {
     Platform platform = new Platform()
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
     Assume.assumeTrue("JWS 3.0 is not supported on RHEL8+ => skipping", platform.isRHEL6() || platform.isRHEL7())
-    Assume.assumeTrue("Tomcat from JWS 3.0 requires at least Java 1.7", Java.isJdk1xOrHigher('1.7'))
+    Assume.assumeTrue("Tomcat from JWS 3.0 requires at least Java 1.7",
+            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk1.7')) ?: Java.isJdk1xOrHigher('1.7')
+    )
+
 
     loadTestProperties("/tomcat8-common-test.properties")
     prepareWorkspace()

--- a/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat8ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat8ConfiguratorIT.groovy
@@ -14,7 +14,7 @@ class BindingsTomcat8ConfiguratorIT extends BindingsTomcatConfiguratorIT {
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
     Assume.assumeTrue("JWS 3.0 is not supported on RHEL8+ => skipping", platform.isRHEL6() || platform.isRHEL7())
     Assume.assumeTrue("Tomcat from JWS 3.0 requires at least Java 1.7",
-            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk1.7')) ?: Java.isJdk1xOrHigher('1.7')
+            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk1.7')) ?: Java.isJdkXOrHigher('1.7')
     )
 
 

--- a/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat9ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat9ConfiguratorIT.groovy
@@ -13,7 +13,7 @@ class BindingsTomcat9ConfiguratorIT extends BindingsTomcatConfiguratorIT {
     Platform platform = new Platform()
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
     Assume.assumeTrue("Tomcat from JWS 5.0 requires at least Java 1.8",
-            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk1.8')) ?: Java.isJdk1xOrHigher('1.8')
+            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk1.8')) ?: Java.isJdkXOrHigher('1.8')
     )
 
     loadTestProperties("/tomcat9-common-test.properties")

--- a/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat9ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat9ConfiguratorIT.groovy
@@ -1,5 +1,6 @@
 package noe.tomcat
 
+import noe.common.DefaultProperties
 import noe.common.utils.Java
 import noe.common.utils.Platform
 import org.junit.Assume
@@ -11,7 +12,9 @@ class BindingsTomcat9ConfiguratorIT extends BindingsTomcatConfiguratorIT {
   public static void beforeClass() {
     Platform platform = new Platform()
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
-    Assume.assumeTrue("Tomcat from JWS 5.0 requires at least Java 1.8", Java.isJdk1xOrHigher('1.8'))
+    Assume.assumeTrue("Tomcat from JWS 5.0 requires at least Java 1.8",
+            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk1.8')) ?: Java.isJdk1xOrHigher('1.8')
+    )
 
     loadTestProperties("/tomcat9-common-test.properties")
     prepareWorkspace()

--- a/testsuite/src/test/groovy/noe/tomcat/JmxTomcat10ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JmxTomcat10ConfiguratorIT.groovy
@@ -15,6 +15,7 @@ class JmxTomcat10ConfiguratorIT extends JmxTomcatConfiguratorIT {
     def serverJavaHomeMatches = java11Indicators.any { DefaultProperties.SERVER_JAVA_HOME?.contains(it) }
 
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
+    Assume.assumeFalse("JWS 6.0 is officially supported on RHEL versions 8 and above", platform.OSVersionLessThan(8));
     Assume.assumeTrue("Tomcat from JWS 6.0 requires at least Java 11",
             serverJavaHomeMatches ?: Java.isJdkXOrHigher('11')
     )

--- a/testsuite/src/test/groovy/noe/tomcat/JmxTomcat10ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JmxTomcat10ConfiguratorIT.groovy
@@ -13,7 +13,7 @@ class JmxTomcat10ConfiguratorIT extends JmxTomcatConfiguratorIT {
     Platform platform = new Platform()
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
     Assume.assumeTrue("Tomcat from JWS 6.0 requires at least Java 11",
-            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk11')) ?: Java.isJdk1xOrHigher('11')
+            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk11')) ?: Java.isJdkXOrHigher('11')
     )
 
     loadTestProperties("/tomcat10-common-test.properties")

--- a/testsuite/src/test/groovy/noe/tomcat/JmxTomcat10ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JmxTomcat10ConfiguratorIT.groovy
@@ -1,5 +1,6 @@
 package noe.tomcat
 
+import noe.common.DefaultProperties
 import noe.common.utils.Java
 import noe.common.utils.Platform
 import org.junit.Assume
@@ -11,7 +12,9 @@ class JmxTomcat10ConfiguratorIT extends JmxTomcatConfiguratorIT {
   public static void beforeClass() {
     Platform platform = new Platform()
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
-    Assume.assumeTrue("Tomcat from JWS 6.0 requires at least Java 11", Java.isJdk1xOrHigher('11'))
+    Assume.assumeTrue("Tomcat from JWS 6.0 requires at least Java 11",
+            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk11')) ?: Java.isJdk1xOrHigher('11')
+    )
 
     loadTestProperties("/tomcat10-common-test.properties")
     prepareWorkspace()

--- a/testsuite/src/test/groovy/noe/tomcat/JmxTomcat10ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JmxTomcat10ConfiguratorIT.groovy
@@ -1,0 +1,20 @@
+package noe.tomcat
+
+import noe.common.utils.Java
+import noe.common.utils.Platform
+import org.junit.Assume
+import org.junit.BeforeClass
+
+class JmxTomcat10ConfiguratorIT extends JmxTomcatConfiguratorIT {
+
+  @BeforeClass
+  public static void beforeClass() {
+    Platform platform = new Platform()
+    Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
+    Assume.assumeTrue("Tomcat from JWS 6.0 requires at least Java 11", Java.isJdk1xOrHigher('11'))
+
+    loadTestProperties("/tomcat10-common-test.properties")
+    prepareWorkspace()
+  }
+
+}

--- a/testsuite/src/test/groovy/noe/tomcat/JmxTomcat10ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JmxTomcat10ConfiguratorIT.groovy
@@ -11,9 +11,12 @@ class JmxTomcat10ConfiguratorIT extends JmxTomcatConfiguratorIT {
   @BeforeClass
   public static void beforeClass() {
     Platform platform = new Platform()
+    def java11Indicators = ['jdk11', 'java-11', 'openjdk-11']
+    def serverJavaHomeMatches = java11Indicators.any { DefaultProperties.SERVER_JAVA_HOME?.contains(it) }
+
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
     Assume.assumeTrue("Tomcat from JWS 6.0 requires at least Java 11",
-            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk11')) ?: Java.isJdkXOrHigher('11')
+            serverJavaHomeMatches ?: Java.isJdkXOrHigher('11')
     )
 
     loadTestProperties("/tomcat10-common-test.properties")

--- a/testsuite/src/test/groovy/noe/tomcat/JmxTomcat8ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JmxTomcat8ConfiguratorIT.groovy
@@ -14,7 +14,7 @@ class JmxTomcat8ConfiguratorIT extends JmxTomcatConfiguratorIT {
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
     Assume.assumeTrue("JWS 3.0 is not supported from RHEL8+ => skipping", platform.isRHEL7())
     Assume.assumeTrue("Tomcat from JWS 3.0 requires at least Java 1.7",
-            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk1.7')) ?: Java.isJdk1xOrHigher('1.7')
+            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk1.7')) ?: Java.isJdkXOrHigher('1.7')
     )
 
 

--- a/testsuite/src/test/groovy/noe/tomcat/JmxTomcat8ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JmxTomcat8ConfiguratorIT.groovy
@@ -1,5 +1,6 @@
 package noe.tomcat
 
+import noe.common.DefaultProperties
 import noe.common.utils.Java
 import noe.common.utils.Platform
 import org.junit.Assume
@@ -12,7 +13,10 @@ class JmxTomcat8ConfiguratorIT extends JmxTomcatConfiguratorIT {
     Platform platform = new Platform()
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
     Assume.assumeTrue("JWS 3.0 is not supported from RHEL8+ => skipping", platform.isRHEL7())
-    Assume.assumeTrue("Tomcat from JWS 3.0 requires at least Java 1.7", Java.isJdk1xOrHigher('1.7'))
+    Assume.assumeTrue("Tomcat from JWS 3.0 requires at least Java 1.7",
+            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk1.7')) ?: Java.isJdk1xOrHigher('1.7')
+    )
+
 
     loadTestProperties("/tomcat8-common-test.properties")
     prepareWorkspace()

--- a/testsuite/src/test/groovy/noe/tomcat/JmxTomcat9ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JmxTomcat9ConfiguratorIT.groovy
@@ -1,5 +1,6 @@
 package noe.tomcat
 
+import noe.common.DefaultProperties
 import noe.common.utils.Java
 import noe.common.utils.Platform
 import org.junit.Assume
@@ -11,7 +12,9 @@ class JmxTomcat9ConfiguratorIT extends JmxTomcatConfiguratorIT {
   public static void beforeClass() {
     Platform platform = new Platform()
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
-    Assume.assumeTrue("Tomcat from JWS requires at least Java 1.8", Java.isJdk1xOrHigher('1.8'))
+    Assume.assumeTrue("Tomcat from JWS 5.0 requires at least Java 1.8",
+            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk1.8')) ?: Java.isJdk1xOrHigher('1.8')
+    )
 
     loadTestProperties("/tomcat9-common-test.properties")
     prepareWorkspace()

--- a/testsuite/src/test/groovy/noe/tomcat/JmxTomcat9ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JmxTomcat9ConfiguratorIT.groovy
@@ -13,7 +13,7 @@ class JmxTomcat9ConfiguratorIT extends JmxTomcatConfiguratorIT {
     Platform platform = new Platform()
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
     Assume.assumeTrue("Tomcat from JWS 5.0 requires at least Java 1.8",
-            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk1.8')) ?: Java.isJdk1xOrHigher('1.8')
+            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk1.8')) ?: Java.isJdkXOrHigher('1.8')
     )
 
     loadTestProperties("/tomcat9-common-test.properties")

--- a/testsuite/src/test/groovy/noe/tomcat/JmxTomcatConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JmxTomcatConfiguratorIT.groovy
@@ -7,7 +7,6 @@ import noe.tomcat.configure.JmxTomcat
 import noe.tomcat.configure.JmxRemoteAccessFileTomcat
 import noe.tomcat.configure.JmxRemotePasswordFileTomcat
 import noe.tomcat.configure.TomcatConfigurator
-import org.junit.After
 import org.junit.Test
 
 import static org.junit.Assert.assertEquals
@@ -29,11 +28,6 @@ import static org.junit.Assert.assertTrue
  */
 abstract class JmxTomcatConfiguratorIT extends TomcatTestAbstract {
   Platform platform = new Platform()
-
-  @After
-  void after() {
-    new File(tomcat.basedir, "bin/setenv." + platform.getScriptSuffix()).delete()
-  }
 
   @Test
   void setJmxPortOnlyChangeExpected() {

--- a/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat10ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat10ConfiguratorIT.groovy
@@ -15,6 +15,7 @@ class JvmRouteTomcat10ConfiguratorIT extends JvmRouteTomcatConfiguratorIT {
         def serverJavaHomeMatches = java11Indicators.any { DefaultProperties.SERVER_JAVA_HOME?.contains(it) }
 
         Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
+        Assume.assumeFalse("JWS 6.0 is officially supported on RHEL versions 8 and above", platform.OSVersionLessThan(8));
         Assume.assumeTrue("Tomcat from JWS 6.0 requires at least Java 11",
                 serverJavaHomeMatches ?: Java.isJdkXOrHigher('11')
         )

--- a/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat10ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat10ConfiguratorIT.groovy
@@ -1,0 +1,20 @@
+package noe.tomcat
+
+import noe.common.utils.Java
+import noe.common.utils.Platform
+import org.junit.Assume
+import org.junit.BeforeClass
+
+class JvmRouteTomcat10ConfiguratorIT extends JvmRouteTomcatConfiguratorIT {
+
+    @BeforeClass
+    public static void beforeClass() {
+        Platform platform = new Platform()
+        Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
+        Assume.assumeTrue("Tomcat from JWS 6.0 requires at least Java 11", Java.isJdk1xOrHigher('11'))
+
+        loadTestProperties("/tomcat10-common-test.properties")
+        prepareWorkspace()
+    }
+
+}

--- a/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat10ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat10ConfiguratorIT.groovy
@@ -14,7 +14,7 @@ class JvmRouteTomcat10ConfiguratorIT extends JvmRouteTomcatConfiguratorIT {
         Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
 
         Assume.assumeTrue("Tomcat from JWS 6.0 requires at least Java 11",
-                (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk11')) ?: Java.isJdk1xOrHigher('11')
+                (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk11')) ?: Java.isJdkXOrHigher('11')
         )
 
         loadTestProperties("/tomcat10-common-test.properties")

--- a/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat10ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat10ConfiguratorIT.groovy
@@ -11,10 +11,12 @@ class JvmRouteTomcat10ConfiguratorIT extends JvmRouteTomcatConfiguratorIT {
     @BeforeClass
     public static void beforeClass() {
         Platform platform = new Platform()
-        Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
+        def java11Indicators = ['jdk11', 'java-11', 'openjdk-11']
+        def serverJavaHomeMatches = java11Indicators.any { DefaultProperties.SERVER_JAVA_HOME?.contains(it) }
 
+        Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
         Assume.assumeTrue("Tomcat from JWS 6.0 requires at least Java 11",
-                (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk11')) ?: Java.isJdkXOrHigher('11')
+                serverJavaHomeMatches ?: Java.isJdkXOrHigher('11')
         )
 
         loadTestProperties("/tomcat10-common-test.properties")

--- a/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat10ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat10ConfiguratorIT.groovy
@@ -1,5 +1,6 @@
 package noe.tomcat
 
+import noe.common.DefaultProperties
 import noe.common.utils.Java
 import noe.common.utils.Platform
 import org.junit.Assume
@@ -11,7 +12,10 @@ class JvmRouteTomcat10ConfiguratorIT extends JvmRouteTomcatConfiguratorIT {
     public static void beforeClass() {
         Platform platform = new Platform()
         Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
-        Assume.assumeTrue("Tomcat from JWS 6.0 requires at least Java 11", Java.isJdk1xOrHigher('11'))
+
+        Assume.assumeTrue("Tomcat from JWS 6.0 requires at least Java 11",
+                (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk11')) ?: Java.isJdk1xOrHigher('11')
+        )
 
         loadTestProperties("/tomcat10-common-test.properties")
         prepareWorkspace()

--- a/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat8ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat8ConfiguratorIT.groovy
@@ -14,7 +14,7 @@ class JvmRouteTomcat8ConfiguratorIT extends JvmRouteTomcatConfiguratorIT {
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
     Assume.assumeTrue("JWS 3.0 is not supported on RHEL8+ => skipping", platform.isRHEL6() || platform.isRHEL7())
     Assume.assumeTrue("Tomcat from JWS 3.0 requires at least Java 1.7",
-            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk1.7')) ?: Java.isJdk1xOrHigher('1.7')
+            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk1.7')) ?: Java.isJdkXOrHigher('1.7')
     )
 
     loadTestProperties("/tomcat8-common-test.properties")

--- a/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat8ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat8ConfiguratorIT.groovy
@@ -1,5 +1,6 @@
 package noe.tomcat
 
+import noe.common.DefaultProperties
 import noe.common.utils.Java
 import noe.common.utils.Platform
 import org.junit.Assume
@@ -12,7 +13,9 @@ class JvmRouteTomcat8ConfiguratorIT extends JvmRouteTomcatConfiguratorIT {
     Platform platform = new Platform()
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
     Assume.assumeTrue("JWS 3.0 is not supported on RHEL8+ => skipping", platform.isRHEL6() || platform.isRHEL7())
-    Assume.assumeTrue("Tomcat from JWS 3.0 requires at least Java 1.7", Java.isJdk1xOrHigher('1.7'))
+    Assume.assumeTrue("Tomcat from JWS 3.0 requires at least Java 1.7",
+            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk1.7')) ?: Java.isJdk1xOrHigher('1.7')
+    )
 
     loadTestProperties("/tomcat8-common-test.properties")
     prepareWorkspace()

--- a/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat9ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat9ConfiguratorIT.groovy
@@ -13,7 +13,7 @@ class JvmRouteTomcat9ConfiguratorIT extends JvmRouteTomcatConfiguratorIT {
     Platform platform = new Platform()
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
     Assume.assumeTrue("Tomcat from JWS 5.0 requires at least Java 1.8",
-            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk1.8')) ?: Java.isJdk1xOrHigher('1.8')
+            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk1.8')) ?: Java.isJdkXOrHigher('1.8')
     )
 
     loadTestProperties("/tomcat9-common-test.properties")

--- a/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat9ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat9ConfiguratorIT.groovy
@@ -1,5 +1,6 @@
 package noe.tomcat
 
+import noe.common.DefaultProperties
 import noe.common.utils.Java
 import noe.common.utils.Platform
 import org.junit.Assume
@@ -11,7 +12,9 @@ class JvmRouteTomcat9ConfiguratorIT extends JvmRouteTomcatConfiguratorIT {
   public static void beforeClass() {
     Platform platform = new Platform()
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
-    Assume.assumeTrue("Tomcat from JWS 3.0 requires at least Java 1.7", Java.isJdk1xOrHigher('1.8'))
+    Assume.assumeTrue("Tomcat from JWS 5.0 requires at least Java 1.8",
+            (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk1.8')) ?: Java.isJdk1xOrHigher('1.8')
+    )
 
     loadTestProperties("/tomcat9-common-test.properties")
     prepareWorkspace()

--- a/testsuite/src/test/groovy/noe/tomcat/TomcatTestAbstract.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/TomcatTestAbstract.groovy
@@ -2,7 +2,6 @@ package noe.tomcat
 
 import noe.common.TestAbstract
 import noe.common.utils.Platform
-import noe.ews.workspace.WorkspaceEws
 import noe.server.Tomcat
 import noe.workspace.ServersWorkspace
 import noe.workspace.WorkspaceTomcat

--- a/testsuite/src/test/resources/core-test.properties
+++ b/testsuite/src/test/resources/core-test.properties
@@ -1,2 +1,2 @@
-apache.core.version=2.4.51
-ews.version=5.7.0
+apache.core.version=2.4.62
+ews.version=6.1.0

--- a/testsuite/src/test/resources/ews-rhel7-test.properties
+++ b/testsuite/src/test/resources/ews-rhel7-test.properties
@@ -1,5 +1,5 @@
-ews.version=3.1.0
+ews.version=5.8.4
 context=ews
 JBPAPP9445_WORKAROUND=true
-apache.core.version=2.4.51
-tomcat.major.version=8
+apache.core.version=2.4.62
+tomcat.major.version=9

--- a/testsuite/src/test/resources/jws5-test.properties
+++ b/testsuite/src/test/resources/jws5-test.properties
@@ -1,4 +1,4 @@
-ews.version=5.7.0
+ews.version=5.8.4
 context=ews
-apache.core.version=2.4.51
+apache.core.version=2.4.62
 tomcat.major.version=9

--- a/testsuite/src/test/resources/jws6-test.properties
+++ b/testsuite/src/test/resources/jws6-test.properties
@@ -1,5 +1,4 @@
 ews.version=6.1.0
 context=ews
-JBPAPP9445_WORKAROUND=true
 apache.core.version=2.4.62
 tomcat.major.version=10

--- a/testsuite/src/test/resources/tomcat10-common-test.properties
+++ b/testsuite/src/test/resources/tomcat10-common-test.properties
@@ -1,5 +1,4 @@
 ews.version=6.1.0
 context=ews
 JBPAPP9445_WORKAROUND=true
-apache.core.version=2.4.62
 tomcat.major.version=10

--- a/testsuite/src/test/resources/tomcat9-common-test.properties
+++ b/testsuite/src/test/resources/tomcat9-common-test.properties
@@ -1,4 +1,4 @@
-ews.version=5.7.0
+ews.version=5.8.4
 context=ews
 JBPAPP9445_WORKAROUND=true
 tomcat.major.version=9


### PR DESCRIPTION
- Adds checks for JWS 6.0
- Adds restrictions in existing tests to ensure compatibility with supported rhel versions
- Enables SERVER_JAVA_HOME for tomcat10
- Updates tests configurations to use the latest compatible httpd, ews versions 
- Updates plugin versions and replaces deprecated directives
- Fixes local debugging issue when loading resources
- Fixes reflection issue related to PID handling by disabling global setting of SERVER_JAVA_HOME
- Fixes NumberFormatException on OSVersionLessThan for rhel7

