### PR TITLE
noe-core improvements

### DIFF
--- a/core/src/main/groovy/noe/common/utils/Platform.groovy
+++ b/core/src/main/groovy/noe/common/utils/Platform.groovy
@@ -3,9 +3,6 @@ package noe.common.utils
 import groovy.util.logging.Slf4j
 import noe.common.DefaultProperties
 
-import java.util.regex.Matcher
-import java.util.regex.Pattern
-
 /**
  *
  * @author Jiri Sedlacek <jsedlace@redhat.com>
@@ -59,8 +56,8 @@ class Platform {
     }
 
     if (isWindows()) {
-      int start = osVersion.indexOf("Server") + "Server ".length()
-      return Integer.parseInt(osVersion.substring(start)) < value
+      int start = osName.indexOf("Server") + "Server ".length()
+      return Integer.parseInt(osName.substring(start)) < value
     }
     return false
   }

--- a/testsuite/src/test/groovy/noe/HttpdKillTestIT.groovy
+++ b/testsuite/src/test/groovy/noe/HttpdKillTestIT.groovy
@@ -23,7 +23,10 @@ class HttpdKillTestIT extends TestAbstract {
     Assume.assumeFalse('JBCS Httpd is not supported on HP-UX => skipping', platform.isHP())
     Assume.assumeFalse('JBCS Httpd is not supported on older versions of RHEL than RHEL 6',
             platform.isRHEL4() || platform.isRHEL5())
-    Assume.assumeTrue("EAP 7.0.0 is officially supported on RHEL versions earlier than 9", platform.OSVersionLessThan(9));
+    if (platform.isRHEL()) {
+      Assume.assumeTrue("EAP 7.0.0 is officially supported on RHEL versions earlier than 9",
+              platform.OSVersionLessThan(9))
+    }
 
     loadTestProperties('/eap7-multiple-jbcs-httpd-test.properties')
     workspace = new ServersWorkspace(

--- a/testsuite/src/test/groovy/noe/MultipleTomcatsIT.groovy
+++ b/testsuite/src/test/groovy/noe/MultipleTomcatsIT.groovy
@@ -22,7 +22,11 @@ class MultipleTomcatsIT extends TestAbstract {
         Platform platform = new Platform()
 
         loadTestProperties('/ews-test.properties')
-        Assume.assumeFalse("JWS 6.0 is officially supported on RHEL versions 8 and above", platform.OSVersionLessThan(8));
+
+        if (platform.isRHEL()) {
+            Assume.assumeFalse("JWS 6.0 is officially supported on RHEL versions 8 and above",
+                platform.OSVersionLessThan(8))
+        }
         Assume.assumeFalse("EWS is not supported on HP-UX => skipping", new Platform().isHP())
         workspace = new ServersWorkspace(
                 new WorkspaceHttpdTomcats(1)

--- a/testsuite/src/test/groovy/noe/TomcatJws5IT.groovy
+++ b/testsuite/src/test/groovy/noe/TomcatJws5IT.groovy
@@ -21,7 +21,10 @@ class TomcatJws5IT extends TestAbstract {
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
     Assume.assumeTrue("Tomcat from JWS 5 requires at least Java 1.8", Java.isJdkXOrHigher('1.8'))
 
-
+    if (platform.isRHEL()) {
+      Assume.assumeTrue("JWS 5.0 is officially supported on RHEL versions 9 and lower",
+              platform.OSVersionLessThan(10));
+    }
 
     loadTestProperties('/jws5-test.properties')
     workspace = new ServersWorkspace(

--- a/testsuite/src/test/groovy/noe/TomcatJws6IT.groovy
+++ b/testsuite/src/test/groovy/noe/TomcatJws6IT.groovy
@@ -19,8 +19,7 @@ class TomcatJws6IT extends TestAbstract {
     static void beforeClass() {
         Platform platform = new Platform()
 
-        def java11Indicators = ['jdk11', 'java-11', 'openjdk-11']
-        def serverJavaHomeMatches = java11Indicators.any { DefaultProperties.SERVER_JAVA_HOME?.contains(it) }
+        def serverJavaHomeMatches = Java.JAVA_11_INDICATORS.any { DefaultProperties.SERVER_JAVA_HOME?.contains(it) }
 
         Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
         Assume.assumeTrue("Tomcat from JWS 6.0 requires at least Java 11",

--- a/testsuite/src/test/groovy/noe/modjk/JkConfiguratorTestIT.groovy
+++ b/testsuite/src/test/groovy/noe/modjk/JkConfiguratorTestIT.groovy
@@ -61,7 +61,8 @@ class JkConfiguratorTestIT extends TestAbstract {
   static Collection<Object[]> data() {
     Platform platform = new Platform()
     boolean modJkPlatforms =
-            (platform.isRHEL() && (platform.isX64())) ||
+            // mod_jk is not shipped in rhel10
+            (platform.OSVersionLessThan(10) && (platform.isX64())) ||
             (platform.isSolaris11() && platform.isX64()) ||
             (platform.isWindows() && platform.isX64())
 

--- a/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat10ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat10ConfiguratorIT.groovy
@@ -11,8 +11,7 @@ class BindingsTomcat10ConfiguratorIT extends BindingsTomcatConfiguratorIT {
   @BeforeClass
   public static void beforeClass() {
     Platform platform = new Platform()
-    def java11Indicators = ['jdk11', 'java-11', 'openjdk-11']
-    def serverJavaHomeMatches = java11Indicators.any { DefaultProperties.SERVER_JAVA_HOME?.contains(it) }
+    def serverJavaHomeMatches = Java.JAVA_11_INDICATORS.any { DefaultProperties.SERVER_JAVA_HOME?.contains(it) }
 
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
     Assume.assumeFalse("JWS 6.0 is officially supported on RHEL versions 8 and above", platform.OSVersionLessThan(8));

--- a/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat10ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat10ConfiguratorIT.groovy
@@ -14,7 +14,10 @@ class BindingsTomcat10ConfiguratorIT extends BindingsTomcatConfiguratorIT {
     def serverJavaHomeMatches = Java.JAVA_11_INDICATORS.any { DefaultProperties.SERVER_JAVA_HOME?.contains(it) }
 
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
-    Assume.assumeFalse("JWS 6.0 is officially supported on RHEL versions 8 and above", platform.OSVersionLessThan(8));
+    if (platform.isRHEL()) {
+      Assume.assumeFalse("JWS 6.0 is officially supported on RHEL versions 8 and above",
+              platform.OSVersionLessThan(8))
+    }
     Assume.assumeTrue("Tomcat from JWS 6.0 requires at least Java 11",
             serverJavaHomeMatches ?: Java.isJdkXOrHigher('11')
     )

--- a/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat9ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/BindingsTomcat9ConfiguratorIT.groovy
@@ -15,7 +15,10 @@ class BindingsTomcat9ConfiguratorIT extends BindingsTomcatConfiguratorIT {
     Assume.assumeTrue("Tomcat from JWS 5.0 requires at least Java 1.8",
             (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk1.8')) ?: Java.isJdkXOrHigher('1.8')
     )
-
+    if (platform.isRHEL()) {
+      Assume.assumeTrue("JWS 5.0 is officially supported on RHEL versions 9 and lower",
+              platform.OSVersionLessThan(10));
+    }
     loadTestProperties("/tomcat9-common-test.properties")
     prepareWorkspace()
   }

--- a/testsuite/src/test/groovy/noe/tomcat/JmxTomcat10ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JmxTomcat10ConfiguratorIT.groovy
@@ -11,8 +11,7 @@ class JmxTomcat10ConfiguratorIT extends JmxTomcatConfiguratorIT {
   @BeforeClass
   public static void beforeClass() {
     Platform platform = new Platform()
-    def java11Indicators = ['jdk11', 'java-11', 'openjdk-11']
-    def serverJavaHomeMatches = java11Indicators.any { DefaultProperties.SERVER_JAVA_HOME?.contains(it) }
+    def serverJavaHomeMatches = Java.JAVA_11_INDICATORS.any { DefaultProperties.SERVER_JAVA_HOME?.contains(it) }
 
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
     Assume.assumeFalse("JWS 6.0 is officially supported on RHEL versions 8 and above", platform.OSVersionLessThan(8));

--- a/testsuite/src/test/groovy/noe/tomcat/JmxTomcat10ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JmxTomcat10ConfiguratorIT.groovy
@@ -14,8 +14,11 @@ class JmxTomcat10ConfiguratorIT extends JmxTomcatConfiguratorIT {
     def serverJavaHomeMatches = Java.JAVA_11_INDICATORS.any { DefaultProperties.SERVER_JAVA_HOME?.contains(it) }
 
     Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
-    Assume.assumeFalse("JWS 6.0 is officially supported on RHEL versions 8 and above", platform.OSVersionLessThan(8));
-    Assume.assumeTrue("Tomcat from JWS 6.0 requires at least Java 11",
+    if (platform.isRHEL()) {
+      Assume.assumeFalse("JWS 6.0 is officially supported on RHEL versions 8 and above",
+              platform.OSVersionLessThan(8))
+    }
+  Assume.assumeTrue("Tomcat from JWS 6.0 requires at least Java 11",
             serverJavaHomeMatches ?: Java.isJdkXOrHigher('11')
     )
 

--- a/testsuite/src/test/groovy/noe/tomcat/JmxTomcat9ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JmxTomcat9ConfiguratorIT.groovy
@@ -15,7 +15,10 @@ class JmxTomcat9ConfiguratorIT extends JmxTomcatConfiguratorIT {
     Assume.assumeTrue("Tomcat from JWS 5.0 requires at least Java 1.8",
             (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk1.8')) ?: Java.isJdkXOrHigher('1.8')
     )
-
+    if (platform.isRHEL()) {
+      Assume.assumeTrue("JWS 5.0 is officially supported on RHEL versions 9 and lower",
+              platform.OSVersionLessThan(10));
+    }
     loadTestProperties("/tomcat9-common-test.properties")
     prepareWorkspace()
   }

--- a/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat10ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat10ConfiguratorIT.groovy
@@ -14,7 +14,10 @@ class JvmRouteTomcat10ConfiguratorIT extends JvmRouteTomcatConfiguratorIT {
         def serverJavaHomeMatches = Java.JAVA_11_INDICATORS.any { DefaultProperties.SERVER_JAVA_HOME?.contains(it) }
 
         Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
-        Assume.assumeFalse("JWS 6.0 is officially supported on RHEL versions 8 and above", platform.OSVersionLessThan(8));
+        if (platform.isRHEL()) {
+            Assume.assumeFalse("JWS 6.0 is officially supported on RHEL versions 8 and above",
+                    platform.OSVersionLessThan(8));
+        }
         Assume.assumeTrue("Tomcat from JWS 6.0 requires at least Java 11",
                 serverJavaHomeMatches ?: Java.isJdkXOrHigher('11')
         )

--- a/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat10ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat10ConfiguratorIT.groovy
@@ -11,8 +11,7 @@ class JvmRouteTomcat10ConfiguratorIT extends JvmRouteTomcatConfiguratorIT {
     @BeforeClass
     public static void beforeClass() {
         Platform platform = new Platform()
-        def java11Indicators = ['jdk11', 'java-11', 'openjdk-11']
-        def serverJavaHomeMatches = java11Indicators.any { DefaultProperties.SERVER_JAVA_HOME?.contains(it) }
+        def serverJavaHomeMatches = Java.JAVA_11_INDICATORS.any { DefaultProperties.SERVER_JAVA_HOME?.contains(it) }
 
         Assume.assumeFalse("JWS is not supported on HP-UX => skipping", platform.isHP())
         Assume.assumeFalse("JWS 6.0 is officially supported on RHEL versions 8 and above", platform.OSVersionLessThan(8));

--- a/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat9ConfiguratorIT.groovy
+++ b/testsuite/src/test/groovy/noe/tomcat/JvmRouteTomcat9ConfiguratorIT.groovy
@@ -15,7 +15,10 @@ class JvmRouteTomcat9ConfiguratorIT extends JvmRouteTomcatConfiguratorIT {
     Assume.assumeTrue("Tomcat from JWS 5.0 requires at least Java 1.8",
             (DefaultProperties.SERVER_JAVA_HOME?.contains('jdk1.8')) ?: Java.isJdkXOrHigher('1.8')
     )
-
+    if (platform.isRHEL()) {
+      Assume.assumeTrue("JWS 5.0 is officially supported on RHEL versions 9 and lower",
+              platform.OSVersionLessThan(10));
+    }
     loadTestProperties("/tomcat9-common-test.properties")
     prepareWorkspace()
   }


### PR DESCRIPTION
- Fixes error on OSVersionLessThan for Windows
- Expands jdk11 indicators
- Enriches tests restrictions with regard to OS versions and application versions