### PR TITLE
deployment-improvements: ensures deployment of asc files

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -168,6 +168,9 @@
                         <goals>
                             <goal>sign</goal>
                         </goals>
+                        <configuration>
+                            <attach>true</attach>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Clearly defines for maven that it should deploy signed artifacts, regardless the default value of the plugin.